### PR TITLE
0.9.1-15 Added Group mode to Graph View

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/node": "^20.10.4",
     "cross-env": "^7.0.3",
-    "electron": "^38.4.0",
+    "electron": "^38.5.0",
     "electron-builder": "^26.0.12",
     "electron-vite": "^3.1.0",
     "typescript": "^5.3.3"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@types/node": "^20.10.4",
     "cross-env": "^7.0.3",
-    "electron": "^38.5.0",
+    "electron": "^38.7.2",
     "electron-builder": "^26.0.12",
     "electron-vite": "^3.1.0",
     "typescript": "^5.3.3"

--- a/docs/graph-view.md
+++ b/docs/graph-view.md
@@ -1,6 +1,6 @@
 # Graph View User Guide
 
-This guide covers the Graph view and its three sub-views: Mind Map, Outline, and Progression. It explains what each sub-view is for, how to use it, and tips for getting the most out of your data.
+This guide covers the Graph view and its sub-views: Mind Map, Outline, Progression, and Group. It explains what each sub-view is for, how to use it, and tips for getting the most out of your data.
 
 ## Overview
 
@@ -9,8 +9,9 @@ The Graph view provides multiple ways to visualize and work with the nodes in yo
 - Mind Map: spatial, free-form view to explore relationships and organize nodes.
 - Outline: structured, tree-based view mirroring folders and allowing virtual orderings.
 - Progression: data-driven line charts built from node metadata to visualize trends across nodes over an X axis you define.
+- Group: define named groups using Filters, visualize relationships between sets, and optionally nest groups.
 
-A sub-view switcher is available within each sub-view for quick navigation (Mind Map → Outline → Progression).
+A sub-view switcher is available within each sub-view for quick navigation (Mind Map → Group → Outline → Progression).
 
 ## Mind Map
 
@@ -77,6 +78,30 @@ The Progression view plots line charts from node metadata.
 
 - Save Image exports a PNG of the current chart. Choose a transparent or solid background. If solid, you can pick the color.
 - Save/Load Config exports/imports the entire Progression configuration as JSON, including filters, selections, ordering, and display options.
+
+## Group
+
+The Group view lets you define up to 50 named groups (sets) using the existing Filters toolbox, and visualize how these sets relate.
+
+Modes
+- Default (Nest off): flat group boxes; draws edges for superset → subset relationships (Hasse diagram) between boxes; equivalent groups share one dotted-border box with combined labels.
+- Nest groups (on): nested group boxes using React Flow sub-flows; duplicates a child group under each minimal parent; hides group-to-group edges (nesting conveys relationships).
+
+Inside a group box
+- Default: shows a count and a compact chip list of node titles; a side column lists a compact set of in-group soft-link arrows when space allows.
+- Option “Show node cards”: renders full Mind Map node cards and in-group soft links.
+
+Options
+- Nest groups, Show node cards, Export/Import JSON, Clear layout, Auto layout.
+- Max cards per group: limit the number of node cards rendered per group (useful for performance on large sets).
+
+Persistence
+- Group configuration, options, and layout are saved per tab in localStorage.
+
+Context menus
+- Right-click blank canvas: Save Map as PNG (uses native file save on desktop/Electron, or browser download on the web).
+- Right-click node card: Mind Map actions (Edit, Delete, etc.).
+- Right-click in-group edge: Unlink.
 
 ### Troubleshooting
 

--- a/frontend/src/components/GroupManagerPanel.tsx
+++ b/frontend/src/components/GroupManagerPanel.tsx
@@ -1,0 +1,95 @@
+import { useMemo, useState } from 'react'
+import { Plus, Trash2, Edit, Filter as FilterIcon, ToggleLeft } from 'lucide-react'
+import NodeFiltersDialog, { DEFAULT_FILTERS, NodeFilterState } from './NodeFiltersDialog'
+import { useGroupViewStore, type GroupDefinition } from '../store/groupViewState'
+import toast from 'react-hot-toast'
+
+const genId = () => (typeof crypto !== 'undefined' && (crypto as any).randomUUID ? (crypto as any).randomUUID() : `g-${Date.now()}-${Math.floor(Math.random()*1e6)}`)
+
+type Props = {
+  className?: string
+}
+
+export default function GroupManagerPanel({ className }: Props) {
+  const groups = useGroupViewStore(s => s.groups)
+  const setGroups = useGroupViewStore(s => s.setGroups)
+  const addGroup = useGroupViewStore(s => s.addGroup)
+  const updateGroup = useGroupViewStore(s => s.updateGroup)
+  const removeGroup = useGroupViewStore(s => s.removeGroup)
+
+  const [filtersOpenFor, setFiltersOpenFor] = useState<string | null>(null)
+
+  const handleAdd = () => {
+    if (groups.length >= 50) {
+      toast.error('Maximum of 50 groups reached')
+      return
+    }
+    const next: GroupDefinition = {
+      id: genId(),
+      name: `Group ${groups.length + 1}`,
+      enabled: true,
+      filters: { ...DEFAULT_FILTERS },
+    }
+    addGroup(next)
+  }
+
+  const handleRename = (groupId: string) => {
+    const g = groups.find(g => g.id === groupId)
+    if (!g) return
+    const name = prompt('Rename group', g.name)
+    if (!name) return
+    updateGroup(groupId, { name })
+  }
+
+  const handleEditFilters = (groupId: string) => setFiltersOpenFor(groupId)
+
+  const handleFiltersChange = (nextFilters: NodeFilterState) => {
+    const id = filtersOpenFor
+    if (!id) return
+    updateGroup(id, { filters: nextFilters })
+  }
+
+  const activeGroup = useMemo(() => groups.find(g => g.id === filtersOpenFor) || null, [filtersOpenFor, groups])
+
+  return (
+    <div className={className}>
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-sm font-medium">Groups</div>
+        <button className="inline-flex items-center gap-1 px-2 py-1 text-xs border border-input rounded hover:bg-accent" onClick={handleAdd}>
+          <Plus className="w-3 h-3" /> Add
+        </button>
+      </div>
+      <div className="flex flex-col gap-1 max-h-80 overflow-auto pr-1">
+        {groups.length === 0 && (
+          <div className="text-xs text-muted-foreground">No groups yet. Click Add to create one.</div>
+        )}
+        {groups.map(g => (
+          <div key={g.id} className="flex items-center gap-2 px-2 py-1 border border-border rounded bg-background/60">
+            <input type="checkbox" checked={g.enabled} onChange={(e)=> updateGroup(g.id, { enabled: e.target.checked })} title="Enable/disable group" />
+            <div className="flex-1 text-sm truncate" title={g.name}>{g.name}</div>
+            <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-accent" onClick={()=> handleRename(g.id)} title="Rename">
+              <Edit className="w-3 h-3" />
+            </button>
+            <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-accent inline-flex items-center gap-1" onClick={()=> handleEditFilters(g.id)} title="Edit filters">
+              <FilterIcon className="w-3 h-3" />
+            </button>
+            <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-destructive hover:text-destructive-foreground" onClick={()=> removeGroup(g.id)} title="Delete">
+              <Trash2 className="w-3 h-3" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {activeGroup && (
+        <NodeFiltersDialog
+          open={!!filtersOpenFor}
+          onClose={() => setFiltersOpenFor(null)}
+          filters={activeGroup.filters}
+          onApply={handleFiltersChange}
+        />
+      )}
+    </div>
+  )
+}
+
+

--- a/frontend/src/components/GroupManagerPanel.tsx
+++ b/frontend/src/components/GroupManagerPanel.tsx
@@ -18,6 +18,8 @@ export default function GroupManagerPanel({ className }: Props) {
   const removeGroup = useGroupViewStore(s => s.removeGroup)
 
   const [filtersOpenFor, setFiltersOpenFor] = useState<string | null>(null)
+  const [renameId, setRenameId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState<string>('')
 
   const handleAdd = () => {
     if (groups.length >= 50) {
@@ -36,9 +38,24 @@ export default function GroupManagerPanel({ className }: Props) {
   const handleRename = (groupId: string) => {
     const g = groups.find(g => g.id === groupId)
     if (!g) return
-    const name = prompt('Rename group', g.name)
-    if (!name) return
+    setRenameId(groupId)
+    setRenameValue(g.name)
+  }
+
+  const handleRenameSave = (groupId: string) => {
+    const name = renameValue.trim()
+    if (!name) {
+      toast.error('Name cannot be empty')
+      return
+    }
     updateGroup(groupId, { name })
+    setRenameId(null)
+    setRenameValue('')
+  }
+
+  const handleRenameCancel = () => {
+    setRenameId(null)
+    setRenameValue('')
   }
 
   const handleEditFilters = (groupId: string) => setFiltersOpenFor(groupId)
@@ -85,7 +102,20 @@ export default function GroupManagerPanel({ className }: Props) {
               <div className="flex items-center gap-2">
                 <input type="checkbox" checked={g.enabled} onChange={(e)=> updateGroup(g.id, { enabled: e.target.checked })} title="Enable/disable group" />
                 <div className="flex-1 min-w-0">
-                  <div className="text-sm truncate" title={g.name}>{g.name}</div>
+                  {renameId === g.id ? (
+                    <div className="flex items-center gap-2">
+                      <input
+                        autoFocus
+                        value={renameValue}
+                        onChange={(e)=> setRenameValue(e.target.value)}
+                        className="w-full px-2 py-1 text-sm border border-input rounded bg-background"
+                      />
+                      <button className="text-xs px-2 py-1 border border-input rounded hover:bg-accent" onClick={()=> handleRenameSave(g.id)}>Save</button>
+                      <button className="text-xs px-2 py-1 border border-input rounded hover:bg-muted" onClick={handleRenameCancel}>Cancel</button>
+                    </div>
+                  ) : (
+                    <div className="text-sm truncate" title={g.name}>{g.name}</div>
+                  )}
                   {summary && (
                     <div className="text-[11px] text-muted-foreground whitespace-normal break-words" title={summary}>
                       Active: {summary}

--- a/frontend/src/components/GroupManagerPanel.tsx
+++ b/frontend/src/components/GroupManagerPanel.tsx
@@ -87,7 +87,7 @@ export default function GroupManagerPanel({ className }: Props) {
                 <div className="flex-1 min-w-0">
                   <div className="text-sm truncate" title={g.name}>{g.name}</div>
                   {summary && (
-                    <div className="text-[11px] text-muted-foreground truncate" title={summary}>
+                    <div className="text-[11px] text-muted-foreground whitespace-normal break-words" title={summary}>
                       Active: {summary}
                     </div>
                   )}

--- a/frontend/src/components/GroupManagerPanel.tsx
+++ b/frontend/src/components/GroupManagerPanel.tsx
@@ -51,6 +51,21 @@ export default function GroupManagerPanel({ className }: Props) {
 
   const activeGroup = useMemo(() => groups.find(g => g.id === filtersOpenFor) || null, [filtersOpenFor, groups])
 
+  const summarizeFilters = (filters: NodeFilterState): string | null => {
+    const parts: string[] = []
+    if ((filters.tags || []).length > 0) parts.push(`tags(${filters.tagsLogic}): ${filters.tags.join(', ')}`)
+    if (filters.nameKeyword) parts.push(`name:"${filters.nameKeyword}"`)
+    if (filters.descriptionKeyword) parts.push(`desc:"${filters.descriptionKeyword}"`)
+    if (filters.startsWith) parts.push(`starts:${filters.startsWith}${filters.startsEndsCaseSensitive ? '' : ' (i)'}`)
+    if (filters.endsWith) parts.push(`ends:${filters.endsWith}${filters.startsEndsCaseSensitive ? '' : ' (i)'}`)
+    if (filters.startDateFrom || filters.startDateTo) parts.push(`start:${filters.startDateFrom || ''}..${filters.startDateTo || ''}`)
+    if (filters.dueDateFrom || filters.dueDateTo) parts.push(`due:${filters.dueDateFrom || ''}..${filters.dueDateTo || ''}`)
+    if (filters.hasAttachments) parts.push('attachments')
+    if ((filters.linkedFromNodeTags || []).length > 0) parts.push(`linkedFrom(${filters.linkedFromNodeTags.length})`)
+    if (parts.length === 0) return null
+    return parts.join('  •  ')
+  }
+
   return (
     <div className={className}>
       <div className="flex items-center justify-between mb-2">
@@ -63,29 +78,41 @@ export default function GroupManagerPanel({ className }: Props) {
         {groups.length === 0 && (
           <div className="text-xs text-muted-foreground">No groups yet. Click Add to create one.</div>
         )}
-        {groups.map(g => (
-          <div key={g.id} className="flex items-center gap-2 px-2 py-1 border border-border rounded bg-background/60">
-            <input type="checkbox" checked={g.enabled} onChange={(e)=> updateGroup(g.id, { enabled: e.target.checked })} title="Enable/disable group" />
-            <div className="flex-1 text-sm truncate" title={g.name}>{g.name}</div>
-            <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-accent" onClick={()=> handleRename(g.id)} title="Rename">
-              <Edit className="w-3 h-3" />
-            </button>
-            <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-accent inline-flex items-center gap-1" onClick={()=> handleEditFilters(g.id)} title="Edit filters">
-              <FilterIcon className="w-3 h-3" />
-            </button>
-            <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-destructive hover:text-destructive-foreground" onClick={()=> removeGroup(g.id)} title="Delete">
-              <Trash2 className="w-3 h-3" />
-            </button>
-          </div>
-        ))}
+        {groups.map(g => {
+          const summary = summarizeFilters(g.filters)
+          return (
+            <div key={g.id} className="px-2 py-1 border border-border rounded bg-background/60">
+              <div className="flex items-center gap-2">
+                <input type="checkbox" checked={g.enabled} onChange={(e)=> updateGroup(g.id, { enabled: e.target.checked })} title="Enable/disable group" />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm truncate" title={g.name}>{g.name}</div>
+                  {summary && (
+                    <div className="text-[11px] text-muted-foreground truncate" title={summary}>
+                      Active: {summary}
+                    </div>
+                  )}
+                </div>
+                <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-accent" onClick={()=> handleRename(g.id)} title="Rename">
+                  <Edit className="w-3 h-3" />
+                </button>
+                <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-accent inline-flex items-center gap-1" onClick={()=> handleEditFilters(g.id)} title="Edit filters">
+                  <FilterIcon className="w-3 h-3" />
+                </button>
+                <button className="text-xs px-1 py-0.5 border border-input rounded hover:bg-destructive hover:text-destructive-foreground" onClick={()=> removeGroup(g.id)} title="Delete">
+                  <Trash2 className="w-3 h-3" />
+                </button>
+              </div>
+            </div>
+          )
+        })}
       </div>
 
       {activeGroup && (
         <NodeFiltersDialog
-          open={!!filtersOpenFor}
+          isOpen={!!filtersOpenFor}
           onClose={() => setFiltersOpenFor(null)}
           filters={activeGroup.filters}
-          onApply={handleFiltersChange}
+          onFiltersChange={handleFiltersChange}
         />
       )}
     </div>

--- a/frontend/src/components/GroupOptionsTray.tsx
+++ b/frontend/src/components/GroupOptionsTray.tsx
@@ -12,6 +12,7 @@ export default function GroupOptionsTray({ projectId, tabId }: Props) {
   const nestGroups = useGroupViewStore(s => s.options.nestGroups)
   const showNodeCards = useGroupViewStore(s => !!s.options.showNodeCards)
   const maxCardsPerGroup = useGroupViewStore(s => s.options.maxCardsPerGroup || 40)
+  const showCapIndicator = useGroupViewStore(s => s.options.showCapIndicator !== false)
   const setOptions = useGroupViewStore(s => s.setOptions)
   const replaceLayout = useGroupViewStore(s => s.replaceLayout)
   const exportConfig = useGroupViewStore(s => s.exportConfig)
@@ -96,6 +97,14 @@ export default function GroupOptionsTray({ projectId, tabId }: Props) {
             className="w-20 px-2 py-1 border border-input rounded bg-background"
           />
         </div>
+        <label className="inline-flex items-center gap-2 text-sm" title="Show a small indicator when node cards are truncated by the cap.">
+          <input
+            type="checkbox"
+            checked={showCapIndicator}
+            onChange={(e) => setOptions({ showCapIndicator: e.target.checked })}
+          />
+          Show cap indicator
+        </label>
         <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent inline-flex items-center gap-2" onClick={handleExport}>
           <Download className="w-4 h-4" /> Export JSON
         </button>

--- a/frontend/src/components/GroupOptionsTray.tsx
+++ b/frontend/src/components/GroupOptionsTray.tsx
@@ -14,11 +14,9 @@ export default function GroupOptionsTray({ projectId, tabId }: Props) {
   const maxCardsPerGroup = useGroupViewStore(s => s.options.maxCardsPerGroup || 40)
   const showCapIndicator = useGroupViewStore(s => s.options.showCapIndicator !== false)
   const setOptions = useGroupViewStore(s => s.setOptions)
-  const replaceLayout = useGroupViewStore(s => s.replaceLayout)
   const exportConfig = useGroupViewStore(s => s.exportConfig)
   const importConfig = useGroupViewStore(s => s.importConfig)
   const saveToStorage = useGroupViewStore(s => s.saveToStorage)
-  const requestLayout = useGroupViewStore(s => s.requestLayout)
 
   const fileRef = useRef<HTMLInputElement | null>(null)
 
@@ -108,18 +106,12 @@ export default function GroupOptionsTray({ projectId, tabId }: Props) {
         <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent inline-flex items-center gap-2" onClick={handleExport}>
           <Download className="w-4 h-4" /> Export JSON
         </button>
-        <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent" onClick={()=> requestLayout()}>
-          Auto layout
-        </button>
         <div className="flex items-center gap-2">
           <input ref={fileRef} type="file" accept="application/json" className="hidden" onChange={handleImport} />
           <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent inline-flex items-center gap-2" onClick={()=> fileRef.current?.click()}>
             <Upload className="w-4 h-4" /> Import JSON
           </button>
         </div>
-        <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent" onClick={()=> replaceLayout({ boxes: {} })}>
-          Clear layout
-        </button>
       </div>
     </div>
   )

--- a/frontend/src/components/GroupOptionsTray.tsx
+++ b/frontend/src/components/GroupOptionsTray.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useRef } from 'react'
+import { useGroupViewStore, type GroupViewPersisted } from '../store/groupViewState'
+import { Download, Upload } from 'lucide-react'
+import toast from 'react-hot-toast'
+
+type Props = {
+  projectId?: string
+  tabId?: string
+}
+
+export default function GroupOptionsTray({ projectId, tabId }: Props) {
+  const nestGroups = useGroupViewStore(s => s.options.nestGroups)
+  const showNodeCards = useGroupViewStore(s => !!s.options.showNodeCards)
+  const maxCardsPerGroup = useGroupViewStore(s => s.options.maxCardsPerGroup || 40)
+  const setOptions = useGroupViewStore(s => s.setOptions)
+  const replaceLayout = useGroupViewStore(s => s.replaceLayout)
+  const exportConfig = useGroupViewStore(s => s.exportConfig)
+  const importConfig = useGroupViewStore(s => s.importConfig)
+  const saveToStorage = useGroupViewStore(s => s.saveToStorage)
+  const requestLayout = useGroupViewStore(s => s.requestLayout)
+
+  const fileRef = useRef<HTMLInputElement | null>(null)
+
+  const handleExport = useCallback(() => {
+    const cfg = exportConfig()
+    const blob = new Blob([JSON.stringify(cfg, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `group-view-${new Date().toISOString().replace(/[:.]/g, '-')}.json`
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+    toast.success('Export started')
+  }, [exportConfig])
+
+  const handleImport = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      try {
+        const text = String(reader.result || '')
+        const obj = JSON.parse(text) as GroupViewPersisted
+        importConfig(obj)
+        if (projectId && tabId) saveToStorage(projectId, tabId)
+        toast.success('Group configuration imported')
+      } catch (err) {
+        toast.error('Failed to import configuration')
+      } finally {
+        if (fileRef.current) fileRef.current.value = ''
+      }
+    }
+    reader.readAsText(file)
+  }, [importConfig, projectId, tabId, saveToStorage])
+
+  return (
+    <div className="bg-background/80 border border-border rounded shadow w-64">
+      <button
+        className="w-full flex items-center justify-between px-2 py-1 text-sm"
+        aria-expanded={true}
+      >
+        <span>Options</span>
+        <span className="text-xs">▾</span>
+      </button>
+      <div className="p-2 flex flex-col gap-2">
+        <label className="inline-flex items-center gap-2 text-sm" title="Display groups as nested boxes; hides edges.">
+          <input
+            type="checkbox"
+            checked={nestGroups}
+            onChange={(e) => setOptions({ nestGroups: e.target.checked })}
+          />
+          Nest groups
+        </label>
+        <label className="inline-flex items-center gap-2 text-sm" title="Render full node cards and soft links inside groups (heavier).">
+          <input
+            type="checkbox"
+            checked={showNodeCards}
+            onChange={(e) => setOptions({ showNodeCards: e.target.checked })}
+          />
+          Show node cards
+        </label>
+        <div className="flex items-center gap-2 text-sm">
+          <label className="whitespace-nowrap" title="Limit the number of node cards rendered per group to protect performance.">Max cards</label>
+          <input
+            type="number"
+            min={5}
+            max={200}
+            value={maxCardsPerGroup}
+            onChange={(e) => {
+              const v = Number(e.target.value)
+              if (!Number.isFinite(v)) return
+              setOptions({ maxCardsPerGroup: Math.max(5, Math.min(200, Math.round(v))) })
+            }}
+            className="w-20 px-2 py-1 border border-input rounded bg-background"
+          />
+        </div>
+        <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent inline-flex items-center gap-2" onClick={handleExport}>
+          <Download className="w-4 h-4" /> Export JSON
+        </button>
+        <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent" onClick={()=> requestLayout()}>
+          Auto layout
+        </button>
+        <div className="flex items-center gap-2">
+          <input ref={fileRef} type="file" accept="application/json" className="hidden" onChange={handleImport} />
+          <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent inline-flex items-center gap-2" onClick={()=> fileRef.current?.click()}>
+            <Upload className="w-4 h-4" /> Import JSON
+          </button>
+        </div>
+        <button className="w-full text-left px-2 py-1 text-sm border border-input rounded hover:bg-accent" onClick={()=> replaceLayout({ boxes: {} })}>
+          Clear layout
+        </button>
+      </div>
+    </div>
+  )
+}
+
+

--- a/frontend/src/components/graph/GroupBoxNode.tsx
+++ b/frontend/src/components/graph/GroupBoxNode.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from 'react'
-import type { NodeProps } from 'react-flow-renderer'
+import { Handle, Position, type NodeProps } from 'react-flow-renderer'
 
 type Chip = { id: string; title: string }
 
@@ -21,7 +21,10 @@ function GroupBoxNode({ data, selected }: NodeProps<Data>) {
   const extra = chips.length > chipItems.length ? chips.length - chipItems.length : 0
   const extraRem = remainderChips.length > remainderItems.length ? remainderChips.length - remainderItems.length : 0
   return (
-    <div className="rounded-md border h-full w-full bg-background text-foreground flex flex-col overflow-hidden" style={{ borderStyle: isEquivalent ? 'dotted' as const : 'solid' as const }}>
+    <div className="rounded-md border h-full w-full bg-background text-foreground flex flex-col overflow-hidden relative" style={{ borderStyle: isEquivalent ? 'dotted' as const : 'solid' as const }}>
+      {/* Invisible handles to satisfy React Flow edges between group boxes */}
+      <Handle type="target" position={Position.Left} id="group-left" className="!w-2 !h-2 opacity-0" />
+      <Handle type="source" position={Position.Right} id="group-right" className="!w-2 !h-2 opacity-0" />
       <div className="px-2 py-1 text-sm font-medium border-b flex items-center justify-between gap-2">
         <span className="truncate" title={label}>{label}</span>
         <span className="text-[11px] text-muted-foreground ml-2 whitespace-nowrap">

--- a/frontend/src/components/graph/GroupBoxNode.tsx
+++ b/frontend/src/components/graph/GroupBoxNode.tsx
@@ -1,0 +1,78 @@
+import { memo, useMemo } from 'react'
+import type { NodeProps } from 'react-flow-renderer'
+
+type Chip = { id: string; title: string }
+
+type Data = {
+  label: string
+  isEquivalent?: boolean
+  chips?: Chip[]
+  remainderChips?: Chip[]
+  showNodeCards?: boolean
+  linkPairs?: Array<{ from: string; to: string }>
+  visibleCardCount?: number
+  totalCardCount?: number
+}
+
+function GroupBoxNode({ data, selected }: NodeProps<Data>) {
+  const { label, isEquivalent, chips = [], remainderChips = [], showNodeCards, linkPairs = [], visibleCardCount, totalCardCount } = data || {}
+  const chipItems = useMemo(() => chips.slice(0, 30), [chips])
+  const remainderItems = useMemo(() => remainderChips.slice(0, 30), [remainderChips])
+  const extra = chips.length > chipItems.length ? chips.length - chipItems.length : 0
+  const extraRem = remainderChips.length > remainderItems.length ? remainderChips.length - remainderItems.length : 0
+  return (
+    <div className="rounded-md border h-full w-full bg-background text-foreground flex flex-col overflow-hidden" style={{ borderStyle: isEquivalent ? 'dotted' as const : 'solid' as const }}>
+      <div className="px-2 py-1 text-sm font-medium border-b flex items-center justify-between gap-2">
+        <span className="truncate" title={label}>{label}</span>
+        <span className="text-[11px] text-muted-foreground ml-2 whitespace-nowrap">
+          {chips.length} nodes
+          {showNodeCards && typeof visibleCardCount === 'number' && typeof totalCardCount === 'number' && totalCardCount > visibleCardCount && (
+            <>
+              {' '}
+              • showing {visibleCardCount}
+            </>
+          )}
+        </span>
+      </div>
+      <div className="p-2 flex-1 overflow-auto">
+        {!showNodeCards && (
+          <div className="flex gap-2">
+            <div className="flex-1 flex flex-col gap-1 min-w-0">
+              {chipItems.map(c => (
+                <div key={c.id} className="px-2 py-0.5 text-xs rounded bg-muted text-muted-foreground truncate" title={c.title}>{c.title}</div>
+              ))}
+              {extra > 0 && (
+                <div className="px-2 py-0.5 text-[11px] text-muted-foreground">+{extra} more</div>
+              )}
+              {remainderItems.length > 0 && (
+                <div className="mt-2">
+                  <div className="text-[11px] font-medium mb-1">Remainder</div>
+                  {remainderItems.map(c => (
+                    <div key={c.id} className="px-2 py-0.5 text-xs rounded bg-muted text-muted-foreground truncate" title={c.title}>{c.title}</div>
+                  ))}
+                  {extraRem > 0 && (
+                    <div className="px-2 py-0.5 text-[11px] text-muted-foreground">+{extraRem} more</div>
+                  )}
+                </div>
+              )}
+            </div>
+            {linkPairs.length > 0 && (
+              <div className="w-24 text-[10px] text-muted-foreground overflow-auto border-l pl-2">
+                {linkPairs.map((p, idx) => (
+                  <div key={idx} className="truncate" title={`${p.from} → ${p.to}`}>→ {p.to}</div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {showNodeCards && (
+          <div className="text-[11px] text-muted-foreground">Node cards view will display full cards and links (toggle in Options)</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default memo(GroupBoxNode)
+
+

--- a/frontend/src/components/graph/GroupBoxNode.tsx
+++ b/frontend/src/components/graph/GroupBoxNode.tsx
@@ -65,14 +65,7 @@ function GroupBoxNode({ data, selected }: NodeProps<Data>) {
             )}
           </div>
         )}
-        {showNodeCards && (
-          <div className="text-[11px] text-muted-foreground">
-            Node cards view
-            {typeof visibleCardCount === 'number' && typeof totalCardCount === 'number' && totalCardCount > visibleCardCount && showCapIndicator && (
-              <span> • {totalCardCount - visibleCardCount} hidden due to cap</span>
-            )}
-          </div>
-        )}
+        {showNodeCards && null}
       </div>
     </div>
   )

--- a/frontend/src/components/graph/GroupBoxNode.tsx
+++ b/frontend/src/components/graph/GroupBoxNode.tsx
@@ -12,10 +12,12 @@ type Data = {
   linkPairs?: Array<{ from: string; to: string }>
   visibleCardCount?: number
   totalCardCount?: number
+  showCapIndicator?: boolean
 }
 
 function GroupBoxNode({ data, selected }: NodeProps<Data>) {
   const { label, isEquivalent, chips = [], remainderChips = [], showNodeCards, linkPairs = [], visibleCardCount, totalCardCount, showCapIndicator } = data || {}
+  const showCap = showCapIndicator !== false
   const chipItems = useMemo(() => chips.slice(0, 30), [chips])
   const remainderItems = useMemo(() => remainderChips.slice(0, 30), [remainderChips])
   const extra = chips.length > chipItems.length ? chips.length - chipItems.length : 0
@@ -29,7 +31,7 @@ function GroupBoxNode({ data, selected }: NodeProps<Data>) {
         <span className="truncate" title={label}>{label}</span>
         <span className="text-[11px] text-muted-foreground ml-2 whitespace-nowrap">
           {chips.length} nodes
-          {showNodeCards && typeof visibleCardCount === 'number' && typeof totalCardCount === 'number' && totalCardCount > visibleCardCount && (
+          {showNodeCards && showCap && typeof visibleCardCount === 'number' && typeof totalCardCount === 'number' && totalCardCount > visibleCardCount && (
             <>
               {' '}
               • showing {visibleCardCount}

--- a/frontend/src/components/graph/GroupBoxNode.tsx
+++ b/frontend/src/components/graph/GroupBoxNode.tsx
@@ -15,7 +15,7 @@ type Data = {
 }
 
 function GroupBoxNode({ data, selected }: NodeProps<Data>) {
-  const { label, isEquivalent, chips = [], remainderChips = [], showNodeCards, linkPairs = [], visibleCardCount, totalCardCount } = data || {}
+  const { label, isEquivalent, chips = [], remainderChips = [], showNodeCards, linkPairs = [], visibleCardCount, totalCardCount, showCapIndicator } = data || {}
   const chipItems = useMemo(() => chips.slice(0, 30), [chips])
   const remainderItems = useMemo(() => remainderChips.slice(0, 30), [remainderChips])
   const extra = chips.length > chipItems.length ? chips.length - chipItems.length : 0
@@ -66,7 +66,12 @@ function GroupBoxNode({ data, selected }: NodeProps<Data>) {
           </div>
         )}
         {showNodeCards && (
-          <div className="text-[11px] text-muted-foreground">Node cards view will display full cards and links (toggle in Options)</div>
+          <div className="text-[11px] text-muted-foreground">
+            Node cards view
+            {typeof visibleCardCount === 'number' && typeof totalCardCount === 'number' && totalCardCount > visibleCardCount && showCapIndicator && (
+              <span> • {totalCardCount - visibleCardCount} hidden due to cap</span>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/components/graph/NodeContextMenu.tsx
+++ b/frontend/src/components/graph/NodeContextMenu.tsx
@@ -30,9 +30,10 @@ interface NodeContextMenuProps {
   isCollapsed?: boolean
   onRemoveLinks?: (nodeId: string) => void
   onExportMapAsPng?: () => void
+  variant?: 'group-pane'
 }
 
-function NodeContextMenu({ x, y, nodeId, edgeId, isFolder, hasTask, onCreateNode, onDeleteNode, onCreateChildNode, onCreateChildFolder, onEditNode, onSeeTask, onUnlinkEdge, onAttachFiles, onUploadFiles, onDeleteMultiple, multiCount = 0, onClose, onToggleTrackTask, onToggleLock, isLocked, onToggleCollapse, isCollapsed, onRemoveLinks, onExportMapAsPng }: NodeContextMenuProps) {
+function NodeContextMenu({ x, y, nodeId, edgeId, isFolder, hasTask, onCreateNode, onDeleteNode, onCreateChildNode, onCreateChildFolder, onEditNode, onSeeTask, onUnlinkEdge, onAttachFiles, onUploadFiles, onDeleteMultiple, multiCount = 0, onClose, onToggleTrackTask, onToggleLock, isLocked, onToggleCollapse, isCollapsed, onRemoveLinks, onExportMapAsPng, variant }: NodeContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
   const { currentProject, currentProjectPath } = useProjectStore()
   const [templates, setTemplates] = useState<Template[]>([])
@@ -51,6 +52,7 @@ function NodeContextMenu({ x, y, nodeId, edgeId, isFolder, hasTask, onCreateNode
 
   // Load templates when menu opens and no nodeId (creating new node)
   useEffect(() => {
+    if (variant === 'group-pane') return
     // Only attempt to load templates if we are creating a new node (no nodeId)
     // And if we have the necessary project information for the current environment.
     if (!nodeId) {
@@ -62,9 +64,10 @@ function NodeContextMenu({ x, y, nodeId, edgeId, isFolder, hasTask, onCreateNode
         loadTemplates();
       }
     }
-  }, [nodeId, currentProject, currentProjectPath]);
+  }, [nodeId, currentProject, currentProjectPath, variant]);
 
   const loadTemplates = async () => {
+    if (variant === 'group-pane') return
     // This initial check is redundant due to the useEffect logic but kept for safety.
     if ((window.electronAPI && !currentProjectPath) && (!window.electronAPI && !currentProject?.id)) {
       console.warn("loadTemplates called without necessary project context.");
@@ -101,6 +104,24 @@ function NodeContextMenu({ x, y, nodeId, edgeId, isFolder, hasTask, onCreateNode
     } finally {
       setIsLoading(false)
     }
+  }
+
+  if (variant === 'group-pane') {
+    return (
+      <div
+        ref={menuRef}
+        className="fixed bg-popover border border-border rounded-md shadow-lg py-1 z-50 min-w-[150px] vw-node-context-menu"
+        style={{ left: x, top: y }}
+      >
+        <button
+          onClick={() => { onExportMapAsPng?.(); onClose(); }}
+          className="w-full px-3 py-1.5 text-sm text-left hover:bg-accent hover:text-accent-foreground flex items-center gap-2"
+        >
+          <ImageDown className="w-3 h-3" />
+          Save as PNG...
+        </button>
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -27,7 +27,7 @@ import CustomNode from '../components/graph/CustomNode'
 import NodeContextMenu from '../components/graph/NodeContextMenu'
 import RemoveLinksModal from '../components/common/RemoveLinksModal'
 import { FileStorage, StoredFile } from '../utils/fileStorage'
-import { Paperclip, Filter, ListTree, Loader2, LineChart, Network } from 'lucide-react'
+import { Paperclip, Filter, ListTree, Loader2, LineChart, Network, Layers } from 'lucide-react'
 import NodeFiltersDialog, { NodeFilterState, DEFAULT_FILTERS } from '../components/NodeFiltersDialog'
 // @ts-ignore: type stub provided in global.d.ts; package installed at runtime
 import * as htmlToImage from 'html-to-image'
@@ -42,6 +42,9 @@ import { NODE_TYPES } from '@verbweaver/shared'
 import toast from 'react-hot-toast'
 import { createNodeFromTemplateDesktop } from '../api/desktop-templates';
 import ProgressionPanel from '../components/progression/ProgressionPanel'
+import GroupView from '../views/GroupView'
+import GroupManagerPanel from '../components/GroupManagerPanel'
+import GroupOptionsTray from '../components/GroupOptionsTray'
 // DnD for Outline
 import {
   DndContext,
@@ -232,7 +235,7 @@ function GraphView() {
   const [positionsReady, setPositionsReady] = useState<boolean>(false)
 
   // Outline subview state
-  type GraphSubView = 'mindmap' | 'outline' | 'progression'
+  type GraphSubView = 'mindmap' | 'outline' | 'progression' | 'group'
   const { getActiveTab, updateTab, updateTabMetadata } = useTabStore()
   const activeGraphTabId = useMemo(() => {
     const t = tabs.find(t => t.id === activeTabId)
@@ -242,7 +245,7 @@ function GraphView() {
     try {
       const tab = useTabStore.getState().getActiveTab()
       const saved = (tab?.metadata as any)?.graphSubView as GraphSubView | undefined
-      if (saved === 'outline' || saved === 'mindmap' || saved === 'progression') return saved
+      if (saved === 'outline' || saved === 'mindmap' || saved === 'progression' || saved === 'group') return saved
     } catch {}
     return 'mindmap'
   })
@@ -321,7 +324,7 @@ function GraphView() {
   useEffect(() => {
     const tab = getActiveTab()
     const saved = (tab?.metadata as any)?.graphSubView as GraphSubView | undefined
-    if (saved === 'outline' || saved === 'mindmap' || saved === 'progression') setSubView(saved)
+    if (saved === 'outline' || saved === 'mindmap' || saved === 'progression' || saved === 'group') setSubView(saved)
     subViewLoadedRef.current = true
   }, [getActiveTab])
 
@@ -339,7 +342,13 @@ function GraphView() {
   useEffect(() => {
     const tab = getActiveTab()
     if (!tab) return
-    const title = subView === 'mindmap' ? 'Graph - Mind Map' : subView === 'outline' ? 'Graph - Outline' : 'Graph - Progression'
+    const title = subView === 'mindmap'
+      ? 'Graph - Mind Map'
+      : subView === 'outline'
+      ? 'Graph - Outline'
+      : subView === 'progression'
+      ? 'Graph - Progression'
+      : 'Graph - Group'
     console.log('[Graph] Updating tab title', { tabId: tab.id, title })
     updateTab(tab.id, { title })
   }, [subView, getActiveTab, updateTab])
@@ -1949,6 +1958,7 @@ function GraphView() {
         <div className="absolute top-2 right-2 z-30 pointer-events-auto vw-overlay">
           <div className="bg-background/80 border border-border rounded p-2 shadow flex flex-col gap-2 items-stretch w-56">
             <button className={'px-2 py-1 bg-accent rounded text-sm'} onClick={()=>setSubView('mindmap')}><span className="inline-flex items-center gap-1"><Network className="w-4 h-4"/>Mind Map</span></button>
+            <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('group')} title="Group"><span className="inline-flex items-center gap-1"><Layers className="w-4 h-4"/>Group</span></button>
             <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('outline')} title="Outline"><span className="inline-flex items-center gap-1"><ListTree className="w-4 h-4"/>Outline</span></button>
             <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('progression')} title="Progression"><span className="inline-flex items-center gap-1"><LineChart className="w-4 h-4"/>Progression</span></button>
             <div className="pt-1 border-t border-border" />
@@ -2094,12 +2104,35 @@ function GraphView() {
       </div>
       )}
 
+      {subView === 'group' && (
+        <div className="h-full w-full relative">
+          {/* Right-side panel for Group view: sub-view switcher */}
+          <div className="absolute top-2 right-2 z-30 pointer-events-auto">
+            <div className="bg-background/80 border border-border rounded p-2 shadow flex flex-col gap-2 items-stretch w-56">
+              <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('mindmap')}><span className="inline-flex items-center gap-1"><Network className="w-4 h-4"/>Mind Map</span></button>
+              <button className={'px-2 py-1 bg-accent rounded text-sm'} onClick={()=>setSubView('group')} disabled><span className="inline-flex items-center gap-1"><Layers className="w-4 h-4"/>Group</span></button>
+              <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('outline')}><span className="inline-flex items-center gap-1"><ListTree className="w-4 h-4"/>Outline</span></button>
+              <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('progression')}><span className="inline-flex items-center gap-1"><LineChart className="w-4 h-4"/>Progression</span></button>
+              <div className="pt-1 border-t border-border" />
+              <GroupManagerPanel />
+            </div>
+          </div>
+          {/* Left options tray */}
+          <div className="absolute top-2 left-2 z-10 pointer-events-auto">
+            <GroupOptionsTray projectId={currentProject?.id} tabId={activeGraphTabId} />
+          </div>
+          {/* Canvas */}
+          <GroupView />
+        </div>
+      )}
+
       {subView === 'outline' && (
         <div className="h-full w-full overflow-auto p-3 text-foreground relative z-0">
           {/* Outline right-side panel */}
           <div className="absolute top-2 right-2 z-30 pointer-events-auto">
             <div className="bg-background/80 border border-border rounded p-2 shadow flex flex-col gap-2 items-stretch w-56">
               <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('mindmap')}><span className="inline-flex items-center gap-1"><Network className="w-4 h-4"/>Mind Map</span></button>
+              <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('group')}><span className="inline-flex items-center gap-1"><Layers className="w-4 h-4"/>Group</span></button>
               <button className={'px-2 py-1 bg-accent rounded text-sm'} onClick={()=>setSubView('outline')} disabled><span className="inline-flex items-center gap-1"><ListTree className="w-4 h-4"/>Outline</span></button>
               <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('progression')}><span className="inline-flex items-center gap-1"><LineChart className="w-4 h-4"/>Progression</span></button>
               <div className="pt-1 border-t border-border" />

--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -2108,7 +2108,7 @@ function GraphView() {
         <div className="h-full w-full relative">
           {/* Right-side panel for Group view: sub-view switcher */}
           <div className="absolute top-2 right-2 z-30 pointer-events-auto">
-            <div className="bg-background/80 border border-border rounded p-2 shadow flex flex-col gap-2 items-stretch w-56">
+            <div className="bg-background/80 border border-border rounded p-2 shadow flex flex-col gap-2 items-stretch w-80">
               <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('mindmap')}><span className="inline-flex items-center gap-1"><Network className="w-4 h-4"/>Mind Map</span></button>
               <button className={'px-2 py-1 bg-accent rounded text-sm'} onClick={()=>setSubView('group')} disabled><span className="inline-flex items-center gap-1"><Layers className="w-4 h-4"/>Group</span></button>
               <button className={'px-2 py-1 text-sm'} onClick={()=>setSubView('outline')}><span className="inline-flex items-center gap-1"><ListTree className="w-4 h-4"/>Outline</span></button>

--- a/frontend/src/store/groupViewState.ts
+++ b/frontend/src/store/groupViewState.ts
@@ -40,7 +40,6 @@ type GroupViewStore = {
   groups: GroupDefinition[]
   options: GroupViewOptions
   layout: GroupViewLayout
-  layoutVersion: number
 
   setGroups: (groups: GroupDefinition[]) => void
   addGroup: (group: GroupDefinition) => void
@@ -49,8 +48,6 @@ type GroupViewStore = {
 
   setOptions: (options: Partial<GroupViewOptions>) => void
   setBoxLayout: (boxId: string, pos: { x: number; y: number; w?: number; h?: number }) => void
-  replaceLayout: (layout: GroupViewLayout) => void
-  requestLayout: () => void
 
   loadFromStorage: (projectId: string, tabId: string) => void
   saveToStorage: (projectId: string, tabId: string) => void
@@ -62,7 +59,6 @@ export const useGroupViewStore = create<GroupViewStore>((set, get) => ({
   groups: [],
   options: { nestGroups: false, showNodeCards: false, maxCardsPerGroup: 40, showCapIndicator: true },
   layout: { boxes: {} },
-  layoutVersion: 0,
 
   setGroups: (groups) => set({ groups }),
   addGroup: (group) => set((s) => ({ groups: [...s.groups, group] })),
@@ -73,8 +69,6 @@ export const useGroupViewStore = create<GroupViewStore>((set, get) => ({
 
   setOptions: (options) => set((s) => ({ options: { ...s.options, ...options } })),
   setBoxLayout: (boxId, pos) => set((s) => ({ layout: { ...s.layout, boxes: { ...s.layout.boxes, [boxId]: pos } } })),
-  replaceLayout: (layout) => set({ layout }),
-  requestLayout: () => set((s) => ({ layoutVersion: s.layoutVersion + 1 })),
 
   loadFromStorage: (projectId, tabId) => {
     try {

--- a/frontend/src/store/groupViewState.ts
+++ b/frontend/src/store/groupViewState.ts
@@ -1,0 +1,139 @@
+import { create } from 'zustand'
+import type { NodeFilterState } from '../components/NodeFiltersDialog'
+
+export type GroupDefinition = {
+  id: string
+  name: string
+  enabled: boolean
+  color?: string
+  filters: NodeFilterState
+}
+
+export type GroupViewOptions = {
+  nestGroups: boolean
+  showNodeCards?: boolean
+  maxCardsPerGroup?: number
+}
+
+export type GroupViewLayout = {
+  boxes: Record<string, { x: number; y: number; w?: number; h?: number }>
+}
+
+export type GroupViewPersisted = {
+  version: 1
+  groups: GroupDefinition[]
+  options: GroupViewOptions
+  layout: GroupViewLayout
+}
+
+const defaultPersisted = (): GroupViewPersisted => ({
+  version: 1,
+  groups: [],
+  options: { nestGroups: false, showNodeCards: false, maxCardsPerGroup: 40 },
+  layout: { boxes: {} },
+})
+
+export const groupStorageKey = (projectId: string, tabId: string) => `vw:groupview:${projectId}:${tabId}`
+
+type GroupViewStore = {
+  groups: GroupDefinition[]
+  options: GroupViewOptions
+  layout: GroupViewLayout
+  layoutVersion: number
+
+  setGroups: (groups: GroupDefinition[]) => void
+  addGroup: (group: GroupDefinition) => void
+  updateGroup: (groupId: string, updates: Partial<GroupDefinition>) => void
+  removeGroup: (groupId: string) => void
+
+  setOptions: (options: Partial<GroupViewOptions>) => void
+  setBoxLayout: (boxId: string, pos: { x: number; y: number; w?: number; h?: number }) => void
+  replaceLayout: (layout: GroupViewLayout) => void
+  requestLayout: () => void
+
+  loadFromStorage: (projectId: string, tabId: string) => void
+  saveToStorage: (projectId: string, tabId: string) => void
+  exportConfig: () => GroupViewPersisted
+  importConfig: (cfg: GroupViewPersisted) => void
+}
+
+export const useGroupViewStore = create<GroupViewStore>((set, get) => ({
+  groups: [],
+  options: { nestGroups: false, showNodeCards: false, maxCardsPerGroup: 40 },
+  layout: { boxes: {} },
+  layoutVersion: 0,
+
+  setGroups: (groups) => set({ groups }),
+  addGroup: (group) => set((s) => ({ groups: [...s.groups, group] })),
+  updateGroup: (groupId, updates) => set((s) => ({
+    groups: s.groups.map(g => (g.id === groupId ? { ...g, ...updates } : g)),
+  })),
+  removeGroup: (groupId) => set((s) => ({ groups: s.groups.filter(g => g.id !== groupId) })),
+
+  setOptions: (options) => set((s) => ({ options: { ...s.options, ...options } })),
+  setBoxLayout: (boxId, pos) => set((s) => ({ layout: { ...s.layout, boxes: { ...s.layout.boxes, [boxId]: pos } } })),
+  replaceLayout: (layout) => set({ layout }),
+  requestLayout: () => set((s) => ({ layoutVersion: s.layoutVersion + 1 })),
+
+  loadFromStorage: (projectId, tabId) => {
+    try {
+      const raw = localStorage.getItem(groupStorageKey(projectId, tabId))
+      if (!raw) return
+      const parsed = JSON.parse(raw) as GroupViewPersisted
+      if (!parsed || parsed.version !== 1) return
+      set({
+        groups: Array.isArray(parsed.groups) ? parsed.groups : [],
+        options: {
+          nestGroups: !!parsed.options?.nestGroups,
+          showNodeCards: !!parsed.options?.showNodeCards,
+          maxCardsPerGroup: typeof parsed.options?.maxCardsPerGroup === 'number' && parsed.options.maxCardsPerGroup > 0 ? Math.min(200, parsed.options.maxCardsPerGroup) : 40,
+        },
+        layout: parsed.layout && parsed.layout.boxes ? parsed.layout : { boxes: {} },
+      })
+    } catch {
+      // ignore
+    }
+  },
+  saveToStorage: (projectId, tabId) => {
+    try {
+      const cfg: GroupViewPersisted = {
+        version: 1,
+        groups: get().groups,
+        options: get().options,
+        layout: get().layout,
+      }
+      localStorage.setItem(groupStorageKey(projectId, tabId), JSON.stringify(cfg))
+    } catch {
+      // ignore
+    }
+  },
+  exportConfig: () => {
+    const cfg: GroupViewPersisted = {
+      version: 1,
+      groups: get().groups,
+      options: get().options,
+      layout: get().layout,
+    }
+    return cfg
+  },
+  importConfig: (cfg) => {
+    if (!cfg || cfg.version !== 1) return
+    // Enforce max 50 groups when importing
+    const groups = Array.isArray(cfg.groups) ? cfg.groups.slice(0, 50).map((g: any) => ({
+      id: String(g?.id || ''),
+      name: String(g?.name || ''),
+      enabled: !!g?.enabled,
+      color: g?.color ? String(g.color) : undefined,
+      filters: (g && g.filters ? g.filters : ({} as any)) as NodeFilterState,
+    })) : []
+    const options = {
+      nestGroups: !!cfg.options?.nestGroups,
+      showNodeCards: !!cfg.options?.showNodeCards,
+      maxCardsPerGroup: typeof cfg.options?.maxCardsPerGroup === 'number' && cfg.options.maxCardsPerGroup > 0 ? Math.min(200, cfg.options.maxCardsPerGroup) : 40,
+    }
+    const layout = cfg.layout && cfg.layout.boxes ? cfg.layout : { boxes: {} }
+    set({ groups, options, layout })
+  },
+}))
+
+

--- a/frontend/src/store/groupViewState.ts
+++ b/frontend/src/store/groupViewState.ts
@@ -13,6 +13,7 @@ export type GroupViewOptions = {
   nestGroups: boolean
   showNodeCards?: boolean
   maxCardsPerGroup?: number
+  showCapIndicator?: boolean
 }
 
 export type GroupViewLayout = {
@@ -29,7 +30,7 @@ export type GroupViewPersisted = {
 const defaultPersisted = (): GroupViewPersisted => ({
   version: 1,
   groups: [],
-  options: { nestGroups: false, showNodeCards: false, maxCardsPerGroup: 40 },
+  options: { nestGroups: false, showNodeCards: false, maxCardsPerGroup: 40, showCapIndicator: true },
   layout: { boxes: {} },
 })
 
@@ -59,7 +60,7 @@ type GroupViewStore = {
 
 export const useGroupViewStore = create<GroupViewStore>((set, get) => ({
   groups: [],
-  options: { nestGroups: false, showNodeCards: false, maxCardsPerGroup: 40 },
+  options: { nestGroups: false, showNodeCards: false, maxCardsPerGroup: 40, showCapIndicator: true },
   layout: { boxes: {} },
   layoutVersion: 0,
 
@@ -87,6 +88,7 @@ export const useGroupViewStore = create<GroupViewStore>((set, get) => ({
           nestGroups: !!parsed.options?.nestGroups,
           showNodeCards: !!parsed.options?.showNodeCards,
           maxCardsPerGroup: typeof parsed.options?.maxCardsPerGroup === 'number' && parsed.options.maxCardsPerGroup > 0 ? Math.min(200, parsed.options.maxCardsPerGroup) : 40,
+          showCapIndicator: parsed.options?.showCapIndicator !== false,
         },
         layout: parsed.layout && parsed.layout.boxes ? parsed.layout : { boxes: {} },
       })
@@ -130,6 +132,7 @@ export const useGroupViewStore = create<GroupViewStore>((set, get) => ({
       nestGroups: !!cfg.options?.nestGroups,
       showNodeCards: !!cfg.options?.showNodeCards,
       maxCardsPerGroup: typeof cfg.options?.maxCardsPerGroup === 'number' && cfg.options.maxCardsPerGroup > 0 ? Math.min(200, cfg.options.maxCardsPerGroup) : 40,
+      showCapIndicator: cfg.options?.showCapIndicator !== false,
     }
     const layout = cfg.layout && cfg.layout.boxes ? cfg.layout : { boxes: {} }
     set({ groups, options, layout })

--- a/frontend/src/utils/grouping.spec.ts
+++ b/frontend/src/utils/grouping.spec.ts
@@ -1,0 +1,51 @@
+// Lightweight tests for grouping utils. Run manually by importing and calling runGroupingTests() in dev.
+import { buildEquivalenceBoxes, computeCoverRelations, computeRemainder } from './grouping'
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message)
+}
+
+export function runGroupingTests(): string {
+  // Equivalence boxes
+  const eq = buildEquivalenceBoxes([
+    { groupId: 'A', nodeIds: ['1', '2', '3'] },
+    { groupId: 'B', nodeIds: ['1', '2', '3'] },
+    { groupId: 'C', nodeIds: ['2', '3'] },
+  ])
+  assert(eq.length === 2, 'Expected 2 equivalence boxes')
+  const boxA = eq.find(b => b.groupIds.includes('A'))!
+  assert(boxA.groupIds.includes('B'), 'A and B should share the same box')
+  assert(boxA.nodeIds.join(',') === '1,2,3', 'Box AB should contain nodes 1,2,3')
+
+  // Cover relations (Hasse)
+  const covers = computeCoverRelations(eq)
+  // AB (1,2,3) should cover C (2,3)
+  const abId = boxA.boxId
+  const cId = eq.find(b => b.groupIds.includes('C'))!.boxId
+  assert(covers.some(e => e.parentBoxId === abId && e.childBoxId === cId), 'AB should cover C')
+
+  // Transitive reduction: A ⊃ B ⊃ C should not include A->C
+  const eq2 = buildEquivalenceBoxes([
+    { groupId: 'A2', nodeIds: ['1', '2', '3'] },
+    { groupId: 'B2', nodeIds: ['2', '3'] },
+    { groupId: 'C2', nodeIds: ['3'] },
+  ])
+  const cov2 = computeCoverRelations(eq2)
+  const a2 = eq2.find(b => b.groupIds.includes('A2'))!.boxId
+  const b2 = eq2.find(b => b.groupIds.includes('B2'))!.boxId
+  const c2 = eq2.find(b => b.groupIds.includes('C2'))!.boxId
+  assert(cov2.some(e => e.parentBoxId === a2 && e.childBoxId === b2), 'A2 should cover B2')
+  assert(cov2.some(e => e.parentBoxId === b2 && e.childBoxId === c2), 'B2 should cover C2')
+  assert(!cov2.some(e => e.parentBoxId === a2 && e.childBoxId === c2), 'A2 should NOT directly cover C2 (transitive)')
+
+  // Remainder
+  const remainder = computeRemainder(['1', '2', '3', '4'], [['2', '3']])
+  assert(remainder.sort().join(',') === ['1', '4'].join(','), 'Remainder should be 1,4')
+
+  return 'Grouping utils tests passed'
+}
+
+// Attach to window for quick manual testing (optional)
+// ;(window as any).runGroupingTests = runGroupingTests
+
+

--- a/frontend/src/utils/grouping.ts
+++ b/frontend/src/utils/grouping.ts
@@ -1,0 +1,102 @@
+export type EquivalenceBox = {
+  boxId: string
+  nodeIds: string[]
+  groupIds: string[]
+}
+
+export const sortIds = (ids: string[]): string[] => [...ids].map(String).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+
+export const setKeyFromIds = (ids: string[]): string => sortIds(ids).join('\x1f')
+
+export const uniqueIds = (ids: string[]): string[] => Array.from(new Set(ids.map(String)))
+
+export const buildEquivalenceBoxes = (groups: Array<{ groupId: string; nodeIds: string[] }>): EquivalenceBox[] => {
+  const map = new Map<string, EquivalenceBox>()
+  for (const { groupId, nodeIds } of groups) {
+    const key = setKeyFromIds(uniqueIds(nodeIds))
+    const existing = map.get(key)
+    if (existing) {
+      existing.groupIds.push(groupId)
+    } else {
+      map.set(key, {
+        boxId: key,
+        nodeIds: sortIds(uniqueIds(nodeIds)),
+        groupIds: [groupId],
+      })
+    }
+  }
+  return Array.from(map.values())
+}
+
+export const isSubset = (a: string[], b: string[]): boolean => {
+  // a ⊆ b
+  if (a.length > b.length) return false
+  const setB = new Set(b)
+  for (const id of a) if (!setB.has(id)) return false
+  return true
+}
+
+export type InclusionEdge = { parentBoxId: string; childBoxId: string }
+
+// Compute Hasse diagram (cover relations) of set inclusion among equivalence boxes
+export const computeCoverRelations = (boxes: EquivalenceBox[]): InclusionEdge[] => {
+  // First, compute all inclusion edges parent -> child where parent.set ⊃ child.set
+  const allEdges: InclusionEdge[] = []
+  for (let i = 0; i < boxes.length; i++) {
+    for (let j = 0; j < boxes.length; j++) {
+      if (i === j) continue
+      const A = boxes[i]
+      const B = boxes[j]
+      if (A.nodeIds.length <= B.nodeIds.length) continue
+      if (isSubset(B.nodeIds, A.nodeIds)) allEdges.push({ parentBoxId: A.boxId, childBoxId: B.boxId })
+    }
+  }
+
+  // Transitive reduction: remove edges that are implied via intermediate nodes
+  const byParent = new Map<string, Set<string>>()
+  const childrenOf = (p: string) => byParent.get(p) || new Set<string>()
+  for (const e of allEdges) {
+    if (!byParent.has(e.parentBoxId)) byParent.set(e.parentBoxId, new Set())
+    byParent.get(e.parentBoxId)!.add(e.childBoxId)
+  }
+
+  // Compute reachability via BFS for each parent
+  const reachable = new Map<string, Set<string>>()
+  const parents = Array.from(byParent.keys())
+  for (const p of parents) {
+    const seen = new Set<string>()
+    const queue: string[] = [...(byParent.get(p) || [])]
+    while (queue.length) {
+      const c = queue.shift()!
+      if (seen.has(c)) continue
+      seen.add(c)
+      const gc = byParent.get(c)
+      if (gc) gc.forEach(x => queue.push(x))
+    }
+    reachable.set(p, seen)
+  }
+
+  // Remove direct edge p->c if there exists an intermediate k such that p->k and k->...->c
+  const reduced: InclusionEdge[] = []
+  for (const e of allEdges) {
+    let implied = false
+    // Check if there exists k != c with p->k and k reaches c
+    const directChildren = Array.from(childrenOf(e.parentBoxId))
+    for (const k of directChildren) {
+      if (k === e.childBoxId) continue
+      const reach = reachable.get(k)
+      if (reach && reach.has(e.childBoxId)) { implied = true; break }
+    }
+    if (!implied) reduced.push(e)
+  }
+
+  return reduced
+}
+
+export const computeRemainder = (parent: string[], children: string[][]): string[] => {
+  const parentSet = new Set(parent)
+  for (const child of children) for (const id of child) parentSet.delete(id)
+  return Array.from(parentSet)
+}
+
+

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -11,7 +11,6 @@ import * as htmlToImage from 'html-to-image'
 import toast from 'react-hot-toast'
 import GroupBoxNode from '../components/graph/GroupBoxNode'
 import CustomNode from '../components/graph/CustomNode'
-import { getLayoutedElements } from '../utils/graphLayout'
 
 const groupNodeTypes: NodeTypes = { groupBox: GroupBoxNode, custom: CustomNode }
 
@@ -556,45 +555,6 @@ export default function GroupView() {
       }
     }
   }, [idToPath, createSoftLink])
-
-  const performAutoLayout = useCallback(() => {
-    if (!options.nestGroups) {
-      // Flat mode: layout group boxes using dagre; keep children relative
-      const groupNodes = flowNodes.filter(n => n.type === 'groupBox')
-      const groupEdges = flowEdges.filter(e => !String(e.id).includes('::e::'))
-      const { nodes: laid } = getLayoutedElements(groupNodes as any, groupEdges as any, { direction: 'TB', nodeSpacing: 160, rankSpacing: 200 })
-      laid.forEach(n => setBoxLayout(n.id, { x: (n as any).position.x, y: (n as any).position.y, w: (n as any).width, h: (n as any).height }))
-    } else {
-      // Nest mode: simple packing - stack child boxes vertically within each parent
-      const groups = flowNodes.filter(n => n.type === 'groupBox')
-      const roots = groups.filter(n => !n.parentNode)
-      const widthOf = (nId: string) => {
-        const n = groups.find(m => m.id === nId)
-        const w = n && n.style && (n.style as any).width ? Number((n.style as any).width) : (options.showNodeCards ? 520 : 260)
-        return Number.isFinite(w) ? w : (options.showNodeCards ? 520 : 260)
-      }
-      const placeChildren = (parentId: string) => {
-        const children = groups.filter(n => n.parentNode === parentId)
-        let y = 28
-        const parentW = widthOf(parentId)
-        children.forEach(c => {
-          const childW = widthOf(c.id)
-          const x = Math.max(16, Math.round((parentW - childW) / 2))
-          setBoxLayout(c.id, { x, y })
-          y += (c.style && (c.style as any).height ? Number((c.style as any).height) : 160) + 16
-          placeChildren(c.id)
-        })
-      }
-      roots.forEach(r => placeChildren(r.id))
-    }
-  }, [options.nestGroups, options.showNodeCards, flowNodes, flowEdges, setBoxLayout])
-
-  // Trigger auto layout via Options tray button
-  const layoutVersion = useGroupViewStore(s => s.layoutVersion)
-  useEffect(() => {
-    if (!layoutVersion) return
-    performAutoLayout()
-  }, [layoutVersion, performAutoLayout])
 
   return (
     <div className="h-full w-full">

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -1,0 +1,563 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useProjectStore } from '../store/projectStore'
+import { useTabStore } from '../store/tabStore'
+import { useGroupViewStore } from '../store/groupViewState'
+import { useNodeStore } from '../store/nodeStore'
+import ReactFlow, { Background, Controls, Edge, Node, NodeTypes, useEdgesState, useNodesState, Connection } from 'react-flow-renderer'
+import { buildEquivalenceBoxes, computeCoverRelations, computeRemainder } from '../utils/grouping'
+import NodeContextMenu from '../components/graph/NodeContextMenu'
+// @ts-ignore: type stub provided in global.d.ts; package installed at runtime
+import * as htmlToImage from 'html-to-image'
+import toast from 'react-hot-toast'
+import GroupBoxNode from '../components/graph/GroupBoxNode'
+import CustomNode from '../components/graph/CustomNode'
+import { getLayoutedElements } from '../utils/graphLayout'
+
+// Placeholder Group view. Will be replaced with React Flow Sub Flows implementation in subsequent tasks.
+export default function GroupView() {
+  const { currentProject } = useProjectStore()
+  const activeTabId = useTabStore(s => s.activeTabId)
+  const tabs = useTabStore(s => s.tabs)
+  const loadFromStorage = useGroupViewStore(s => s.loadFromStorage)
+  const saveToStorage = useGroupViewStore(s => s.saveToStorage)
+  const groups = useGroupViewStore(s => s.groups)
+  const options = useGroupViewStore(s => s.options)
+  const layout = useGroupViewStore(s => s.layout)
+  const setBoxLayout = useGroupViewStore(s => s.setBoxLayout)
+  const { nodes: verbweaverNodes, deleteNode, createSoftLink, removeSoftLink } = useNodeStore()
+  const { addEditorTab } = useTabStore()
+
+  // Check if we're in Electron
+  const isElectron = typeof window !== 'undefined' && (window as any).electronAPI !== undefined
+
+  useEffect(() => {
+    const tab = tabs.find(t => t.id === activeTabId)
+    const graphTabId = tab && tab.type === 'graph' ? tab.id : undefined
+    if (currentProject?.id && graphTabId) {
+      loadFromStorage(currentProject.id, graphTabId)
+    }
+  }, [currentProject?.id, activeTabId, tabs, loadFromStorage])
+
+  // Debounced persistence when groups/options/layout change
+  useEffect(() => {
+    const tab = tabs.find(t => t.id === activeTabId)
+    const graphTabId = tab && tab.type === 'graph' ? tab.id : undefined
+    if (!currentProject?.id || !graphTabId) return
+    const h = window.setTimeout(() => {
+      try { saveToStorage(currentProject.id!, graphTabId) } catch {}
+    }, 400)
+    return () => window.clearTimeout(h)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groups, options, layout])
+  // Compute group node sets and equivalence boxes
+  const equivalence = useMemo(() => {
+    const enabled = groups.filter(g => g.enabled)
+    if (enabled.length === 0) return { boxes: [], byId: new Map<string, { name: string }>() }
+    const byId = new Map(enabled.map(g => [g.id, { name: g.name }]))
+    const nodesArr = Array.from(verbweaverNodes.values() || [])
+
+    const normalizeId = (s: string) => String(s || '').replace(/^node-/, '')
+    const matches = (node: any, filters: any): boolean => {
+      const meta = node?.metadata || {}
+      const usingFilters = (
+        (filters.tags || []).length > 0 || filters.nameKeyword || filters.descriptionKeyword || filters.startsWith || filters.endsWith ||
+        filters.startDateFrom || filters.startDateTo || filters.dueDateFrom || filters.dueDateTo || filters.hasAttachments || (filters.linkedFromNodeTags || []).length > 0
+      )
+      if (!usingFilters) return true
+      const title = String(meta?.title || node.name || '')
+      const description = String(meta?.description || '')
+      const tags: string[] = Array.isArray(meta?.tags) ? meta.tags.map(String) : []
+      const startDate = String(meta?.task?.startDate || '')
+      const dueDate = String(meta?.task?.dueDate || '')
+      const files = Array.isArray(meta?.task?.files) ? meta.task.files : []
+      const nodeId = String(meta?.id || '')
+      if (filters.nameKeyword && !title.toLowerCase().includes(String(filters.nameKeyword).toLowerCase())) return false
+      if (filters.descriptionKeyword && !description.toLowerCase().includes(String(filters.descriptionKeyword).toLowerCase())) return false
+      if (filters.startsWith) {
+        if (filters.startsEndsCaseSensitive) {
+          if (!title.startsWith(filters.startsWith)) return false
+        } else if (!title.toLowerCase().startsWith(String(filters.startsWith).toLowerCase())) return false
+      }
+      if (filters.endsWith) {
+        if (filters.startsEndsCaseSensitive) {
+          if (!title.endsWith(filters.endsWith)) return false
+        } else if (!title.toLowerCase().endsWith(String(filters.endsWith).toLowerCase())) return false
+      }
+      if ((filters.tags || []).length > 0) {
+        const set = new Set(tags.map((t: string) => t.toLowerCase()))
+        const wanted = (filters.tags || []).map((t: string) => t.toLowerCase())
+        if (filters.tagsLogic === 'ANY') {
+          if (!wanted.some((t: string) => set.has(t))) return false
+        } else if (!wanted.every((t: string) => set.has(t))) return false
+      }
+      if (filters.startDateFrom && (!startDate || startDate < filters.startDateFrom)) return false
+      if (filters.startDateTo && (!startDate || startDate > filters.startDateTo)) return false
+      if (filters.dueDateFrom && (!dueDate || dueDate < filters.dueDateFrom)) return false
+      if (filters.dueDateTo && (!dueDate || dueDate > filters.dueDateTo)) return false
+      if (filters.hasAttachments) {
+        if (!Array.isArray(files) || files.length === 0) return false
+      }
+      if ((filters.linkedFromNodeTags || []).length > 0) {
+        const sourceIds = new Set<string>((filters.linkedFromNodeTags || []).map(normalizeId).filter(Boolean))
+        const outgoingTargetIds = new Set<string>()
+        if (sourceIds.size > 0) {
+          for (const n of verbweaverNodes.values()) {
+            const nid = n?.metadata?.id
+            if (nid && sourceIds.has(String(nid))) {
+              const links: string[] = Array.isArray(n?.metadata?.links) ? n.metadata.links : []
+              links.forEach((id: string) => { if (id) outgoingTargetIds.add(String(id)) })
+            }
+          }
+        }
+        if (!nodeId || !outgoingTargetIds.has(nodeId)) return false
+      }
+      return true
+    }
+
+    const groupNodes = enabled.map(g => ({
+      groupId: g.id,
+      nodeIds: nodesArr
+        .filter(n => matches(n, g.filters))
+        .map(n => String(n?.metadata?.id || ''))
+        .filter(Boolean),
+    }))
+
+    const boxes = buildEquivalenceBoxes(groupNodes)
+    return { boxes, byId }
+  }, [groups, verbweaverNodes])
+
+  // Build maps for metadata lookup
+  const idToMeta = useMemo(() => {
+    const m = new Map<string, { title: string; links: string[] }>()
+    for (const n of verbweaverNodes.values()) {
+      const id = String(n?.metadata?.id || '')
+      if (!id) continue
+      m.set(id, { title: String(n?.metadata?.title || n?.name || id), links: Array.isArray(n?.metadata?.links) ? n?.metadata?.links.map(String) : [] })
+    }
+    return m
+  }, [verbweaverNodes])
+  const idToPath = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const [path, n] of verbweaverNodes.entries()) {
+      const id = String(n?.metadata?.id || '')
+      if (!id) continue
+      if (!m.has(id)) m.set(id, path)
+    }
+    return m
+  }, [verbweaverNodes])
+
+  // Build flow nodes and edges
+  const { flowNodes, flowEdges } = useMemo(() => {
+    const nodes: Node[] = []
+    const edges: Edge[] = []
+    const boxIdToName = new Map<string, string>(
+      equivalence.boxes.map(b => [b.boxId, b.groupIds.map(id => equivalence.byId.get(id)?.name || id).join(', ')])
+    )
+
+    // Simple grid for initial positions if not saved
+    const gridW = 260, gridH = 140, perRow = 3
+    const covers = computeCoverRelations(equivalence.boxes)
+    const parentsOf = new Map<string, Set<string>>()
+    const childrenOf = new Map<string, Set<string>>()
+    for (const e of covers) {
+      if (!parentsOf.has(e.childBoxId)) parentsOf.set(e.childBoxId, new Set())
+      parentsOf.get(e.childBoxId)!.add(e.parentBoxId)
+      if (!childrenOf.has(e.parentBoxId)) childrenOf.set(e.parentBoxId, new Set())
+      childrenOf.get(e.parentBoxId)!.add(e.childBoxId)
+    }
+    const topLevel = equivalence.boxes.filter(b => !(parentsOf.get(b.boxId)?.size))
+
+    const chipsFor = (ids: string[]) => ids.map(id => ({ id, title: idToMeta.get(id)?.title || id }))
+    const linkPairsFor = (ids: string[]) => {
+      const idSet = new Set(ids)
+      const pairs: Array<{ from: string; to: string }> = []
+      ids.forEach(from => {
+        const links = idToMeta.get(from)?.links || []
+        links.forEach(to => { if (idSet.has(String(to))) pairs.push({ from, to: String(to) }) })
+      })
+      return pairs.slice(0, 12).map(p => ({ from: idToMeta.get(p.from)?.title || p.from, to: idToMeta.get(p.to)?.title || p.to }))
+    }
+
+    const maxCards = Math.max(5, Math.min(200, Number(options.maxCardsPerGroup || 40)))
+    if (!options.nestGroups) {
+      equivalence.boxes.forEach((b, idx) => {
+        const saved = layout.boxes[b.boxId]
+        const x = saved?.x ?? (idx % perRow) * gridW
+        const y = saved?.y ?? Math.floor(idx / perRow) * gridH
+        const isEq = b.groupIds.length > 1
+        const totalCount = b.nodeIds.length
+        nodes.push({
+          id: b.boxId,
+          data: { label: boxIdToName.get(b.boxId) || 'Group', isEquivalent: isEq, chips: chipsFor(b.nodeIds), linkPairs: linkPairsFor(b.nodeIds), showNodeCards: !!options.showNodeCards, visibleCardCount: Math.min(totalCount, maxCards), totalCardCount: totalCount },
+          position: { x, y },
+          style: { width: 260, height: 160 },
+          type: 'groupBox',
+          draggable: true,
+        })
+
+        // Show full node cards inside group (flat mode: all nodes of the set)
+        if (options.showNodeCards) {
+          const childIds = b.nodeIds.slice(0, maxCards)
+          const columns = 2
+          const cardW = 180
+          const cardH = 80
+          const padX = 12, padY = 28
+          childIds.forEach((cid, cidx) => {
+            const col = cidx % columns
+            const row = Math.floor(cidx / columns)
+            const cx = padX + col * (cardW + 12)
+            const cy = padY + row * (cardH + 12)
+            const meta = idToMeta.get(cid)
+            const path = idToPath.get(cid)
+            const storeNode = path ? verbweaverNodes.get(path) : undefined
+            nodes.push({
+              id: `${b.boxId}::n::${cid}`,
+              parentNode: b.boxId,
+              position: { x: cx, y: cy },
+              type: 'custom',
+              draggable: false,
+              data: {
+                label: meta?.title || cid,
+                type: String(storeNode?.metadata?.type || ''),
+                metadata: storeNode?.metadata,
+              },
+              extent: 'parent' as any,
+            } as any)
+          })
+          // Intra-group soft-link edges between child nodes
+          const idSet = new Set(childIds)
+          childIds.forEach(from => {
+            const links = idToMeta.get(from)?.links || []
+            links.forEach(to => {
+              if (idSet.has(String(to))) {
+                edges.push({
+                  id: `${b.boxId}::e::${from}->${to}`,
+                  source: `${b.boxId}::n::${from}`,
+                  target: `${b.boxId}::n::${to}`,
+                  type: 'default',
+                })
+              }
+            })
+          })
+        }
+      })
+      // Flat mode: edges for superset/subset cover relations
+      covers.forEach(e => {
+        edges.push({ id: `${e.parentBoxId}->${e.childBoxId}`, source: e.parentBoxId, target: e.childBoxId })
+      })
+    } else {
+      // Nesting mode: recursively place children under each parent; duplicate children under multiple parents
+      const placeBox = (boxId: string, parent?: string, depth: number = 0, idx: number = 0) => {
+        const b = equivalence.boxes.find(x => x.boxId === boxId)
+        if (!b) return
+        const baseId = parent ? `${boxId}__under__${parent}` : boxId
+        const saved = layout.boxes[baseId] || layout.boxes[boxId]
+        const x = saved?.x ?? ((idx % perRow) * gridW + depth * 12)
+        const y = saved?.y ?? (Math.floor(idx / perRow) * gridH)
+        const isEq = b.groupIds.length > 1
+
+        // If nested, parent sees only remainder; the child shows its own chips
+        const directChildren = Array.from(childrenOf.get(boxId) || [])
+        const remainder = directChildren.length > 0 ? computeRemainder(b.nodeIds, directChildren.map(cid => {
+          const cb = equivalence.boxes.find(x => x.boxId === cid)
+          return cb ? cb.nodeIds : []
+        })) : b.nodeIds
+        const isRoot = !parent
+        const displayedSet = isRoot ? remainder : b.nodeIds
+        const totalCount = displayedSet.length
+
+        // Estimate height for root boxes in nested mode and larger boxes in card mode
+        const estimateHeight = () => {
+          if (!options.showNodeCards) return 160
+          const count = (parent ? b.nodeIds : remainder).length
+          const rows = Math.ceil(Math.min(count, maxCards) / 2)
+          return 28 + rows * (80 + 12) + 24 // header + rows + padding
+        }
+
+        nodes.push({
+          id: baseId,
+          data: {
+            label: boxIdToName.get(boxId) || 'Group',
+            isEquivalent: isEq,
+            chips: chipsFor(displayedSet),
+            remainderChips: [],
+            linkPairs: linkPairsFor(displayedSet),
+            showNodeCards: !!options.showNodeCards,
+            visibleCardCount: Math.min(totalCount, maxCards),
+            totalCardCount: totalCount,
+          },
+          position: { x, y },
+          style: { width: options.showNodeCards ? (parent ? 480 : 520) : (parent ? 240 : 260), height: estimateHeight() },
+          type: 'groupBox',
+          draggable: !parent,
+          parentNode: parent,
+          extent: parent ? 'parent' : undefined,
+        } as any)
+
+        // In nested mode with node cards, render only remainder nodes inside the parent box;
+        // child boxes will render their own nodes.
+        if (options.showNodeCards) {
+          const childIds = (parent ? b.nodeIds : remainder).slice(0, maxCards)
+          const columns = 2
+          const cardW = 180
+          const cardH = 80
+          const padX = 12, padY = 28
+          childIds.forEach((cid, cidx) => {
+            const col = cidx % columns
+            const row = Math.floor(cidx / columns)
+            const cx = padX + col * (cardW + 12)
+            const cy = padY + row * (cardH + 12)
+            const meta = idToMeta.get(cid)
+            const path = idToPath.get(cid)
+            const storeNode = path ? verbweaverNodes.get(path) : undefined
+            nodes.push({
+              id: `${baseId}::n::${cid}`,
+              parentNode: baseId,
+              position: { x: cx, y: cy },
+              type: 'custom',
+              draggable: false,
+              data: {
+                label: meta?.title || cid,
+                type: String(storeNode?.metadata?.type || ''),
+                metadata: storeNode?.metadata,
+              },
+              extent: 'parent' as any,
+            } as any)
+          })
+          // Soft-link edges restricted to childIds within this base box
+          const idSet = new Set(childIds)
+          childIds.forEach(from => {
+            const links = idToMeta.get(from)?.links || []
+            links.forEach(to => {
+              if (idSet.has(String(to))) {
+                edges.push({
+                  id: `${baseId}::e::${from}->${to}`,
+                  source: `${baseId}::n::${from}`,
+                  target: `${baseId}::n::${to}`,
+                  type: 'default',
+                })
+              }
+            })
+          })
+        }
+
+        // Recurse children: duplicate under this baseId
+        directChildren.forEach((cid, cidx) => placeBox(cid, baseId, depth + 1, cidx))
+      }
+
+      topLevel.forEach((b, idx) => placeBox(b.boxId, undefined, 0, idx))
+    }
+
+    return { flowNodes: nodes, flowEdges: edges }
+  }, [equivalence, layout.boxes, options.nestGroups, options.showNodeCards, idToMeta])
+
+  const [nodesState, setNodesState, onNodesChange] = useNodesState(flowNodes)
+  const [edgesState, setEdgesState, onEdgesChange] = useEdgesState(flowEdges)
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId?: string; edgeId?: string } | null>(null)
+
+  useEffect(() => { setNodesState(flowNodes) }, [flowNodes, setNodesState])
+  useEffect(() => { setEdgesState(flowEdges) }, [flowEdges, setEdgesState])
+
+  const onNodeDragStop = useCallback((_: any, n: Node) => {
+    if (!n?.id) return
+    setBoxLayout(n.id, { x: n.position.x, y: n.position.y, w: n.width, h: n.height })
+    const tab = tabs.find(t => t.id === activeTabId)
+    const graphTabId = tab && tab.type === 'graph' ? tab.id : undefined
+    if (currentProject?.id && graphTabId) {
+      saveToStorage(currentProject.id, graphTabId)
+    }
+  }, [setBoxLayout, saveToStorage, tabs, activeTabId, currentProject?.id])
+
+  const exportMapAsPng = useCallback(async () => {
+    try {
+      const el = document.querySelector('.react-flow__renderer') as HTMLElement
+      const viewport = document.querySelector('.react-flow') as HTMLElement
+      const target = el || viewport || document.body
+      const dataUrl = await htmlToImage.toPng(target, { backgroundColor: getComputedStyle(document.body).getPropertyValue('--background') || '#fff' })
+      const filename = `groups-${new Date().toISOString().replace(/[:.]/g,'-')}.png`
+      if (isElectron && (window as any).electronAPI?.saveBinaryFile) {
+        const bin = await (await fetch(dataUrl)).arrayBuffer()
+        const result = await (window as any).electronAPI.saveBinaryFile(new Uint8Array(bin), filename)
+        if (!result?.canceled) toast.success('Map saved')
+      } else {
+        const link = document.createElement('a')
+        link.href = dataUrl
+        link.download = filename
+        document.body.appendChild(link)
+        link.click()
+        link.remove()
+        toast.success('Download started')
+      }
+    } catch (e) {
+      toast.error('Failed to export map')
+    } finally {
+      setContextMenu(null)
+    }
+  }, [isElectron])
+
+  const parseUnderlyingId = (nodeId: string): string | null => {
+    const marker = '::n::'
+    const idx = nodeId.indexOf(marker)
+    if (idx === -1) return null
+    return nodeId.slice(idx + marker.length)
+  }
+
+  const onNodeContextMenu = useCallback((e: any, n: Node) => {
+    e.preventDefault()
+    const underlying = parseUnderlyingId(n.id)
+    if (!underlying) return // ignore group box context here; pane context handles export
+    setContextMenu({ x: e.clientX, y: e.clientY, nodeId: underlying })
+  }, [])
+
+  const onEdgeContextMenu = useCallback((e: any, edge: Edge) => {
+    e.preventDefault()
+    // Only allow unlink for internal in-group edges with ::e:: pattern
+    if (edge.id.includes('::e::')) {
+      setContextMenu({ x: e.clientX, y: e.clientY, edgeId: edge.id })
+    }
+  }, [])
+
+  const handleEditNode = useCallback((underlyingId?: string) => {
+    if (!underlyingId) return
+    const path = idToPath.get(underlyingId)
+    const meta = Array.from(verbweaverNodes.values()).find(v => String(v?.metadata?.id || '') === underlyingId)
+    if (path && meta) addEditorTab(path, meta.name)
+  }, [idToPath, verbweaverNodes, addEditorTab])
+
+  const handleDeleteNode = useCallback(async (underlyingId?: string) => {
+    if (!underlyingId) return
+    const path = idToPath.get(underlyingId)
+    if (path) await deleteNode(path)
+  }, [idToPath, deleteNode])
+
+  const handleUnlinkEdge = useCallback(async (edgeId?: string) => {
+    if (!edgeId) return
+    // edge id format: <base>::e::<from>-><to>
+    const marker = '::e::'
+    const idx = edgeId.indexOf(marker)
+    if (idx === -1) return
+    const rest = edgeId.slice(idx + marker.length)
+    const parts = rest.split('->')
+    if (parts.length !== 2) return
+    const from = parts[0]
+    const to = parts[1]
+    const fromPath = idToPath.get(from)
+    const toPath = idToPath.get(to)
+    if (fromPath && toPath) {
+      await removeSoftLink(fromPath, toPath)
+      setEdgesState(prev => prev.filter(e => e.id !== edgeId))
+    }
+  }, [idToPath, removeSoftLink, setEdgesState])
+
+  const onConnect = useCallback(async (conn: Connection) => {
+    const getUnderlying = (nid?: string | null) => (nid ? parseUnderlyingId(nid) : null)
+    const s = getUnderlying(conn.source)
+    const t = getUnderlying(conn.target)
+    if (!s || !t) return
+    const sp = idToPath.get(s)
+    const tp = idToPath.get(t)
+    if (sp && tp) {
+      await createSoftLink(sp, tp)
+      // Optimistic edge for in-group if both nodes share same base id prefix before '::n::'
+      const base = (nid: string) => nid.split('::n::')[0]
+      if (base(conn.source!) === base(conn.target!)) {
+        const baseId = base(conn.source!)
+        setEdgesState(prev => ([...prev, { id: `${baseId}::e::${s}->${t}`, source: `${baseId}::n::${s}`, target: `${baseId}::n::${t}` }]))
+      }
+    }
+  }, [idToPath, createSoftLink, setEdgesState])
+
+  const performAutoLayout = useCallback(() => {
+    if (!options.nestGroups) {
+      // Flat mode: layout group boxes using dagre; keep children relative
+      const groupNodes = nodesState.filter(n => n.type === 'groupBox')
+      const groupEdges = edgesState.filter(e => !String(e.id).includes('::e::'))
+      const { nodes: laid } = getLayoutedElements(groupNodes as any, groupEdges as any, { direction: 'TB', nodeSpacing: 160, rankSpacing: 200 })
+      laid.forEach(n => setBoxLayout(n.id, { x: n.position.x, y: n.position.y, w: n.width, h: n.height }))
+      setNodesState(prev => prev.map(n => {
+        const found = laid.find(m => m.id === n.id)
+        return found ? { ...n, position: found.position } : n
+      }))
+    } else {
+      // Nest mode: simple packing - stack child boxes vertically within each parent
+      const updated: Record<string, { x: number; y: number }> = {}
+      const groups = nodesState.filter(n => n.type === 'groupBox')
+      const roots = groups.filter(n => !n.parentNode)
+      const getWidth = (nId: string) => {
+        const n = nodesState.find(m => m.id === nId)
+        const w = n && n.style && (n.style as any).width ? Number((n.style as any).width) : (options.showNodeCards ? 520 : 260)
+        return Number.isFinite(w) ? w : (options.showNodeCards ? 520 : 260)
+      }
+      const placeChildren = (parentId: string) => {
+        const children = groups.filter(n => n.parentNode === parentId)
+        let y = 28
+        const parentW = getWidth(parentId)
+        children.forEach((c, idx) => {
+          const childW = getWidth(c.id)
+          const x = Math.max(16, Math.round((parentW - childW) / 2))
+          updated[c.id] = { x, y }
+          y += (c.style && (c.style as any).height ? Number((c.style as any).height) : 160) + 16
+          // Recurse
+          placeChildren(c.id)
+        })
+      }
+      roots.forEach(r => placeChildren(r.id))
+      // Apply child positions relative to parent and expand parent size
+      setNodesState(prev => prev.map(n => {
+        if (updated[n.id]) {
+          return { ...n, position: updated[n.id] }
+        }
+        if (!n.parentNode && n.type === 'groupBox') {
+          // expand root boxes to fit children roughly
+          return { ...n, style: { ...(n.style || {}), width: 520, height: 400 } }
+        }
+        return n
+      }))
+    }
+  }, [options.nestGroups, nodesState, edgesState, setNodesState, setBoxLayout])
+
+  // Trigger auto layout via Options tray button
+  const layoutVersion = useGroupViewStore(s => s.layoutVersion)
+  useEffect(() => {
+    if (!layoutVersion) return
+    performAutoLayout()
+  }, [layoutVersion, performAutoLayout])
+
+  return (
+    <div className="h-full w-full">
+      <ReactFlow
+        nodes={nodesState}
+        edges={edgesState}
+        nodeTypes={{ groupBox: GroupBoxNode, custom: CustomNode } as NodeTypes}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeDragStop={onNodeDragStop}
+        onNodeContextMenu={onNodeContextMenu}
+        onEdgeContextMenu={onEdgeContextMenu}
+        onConnect={onConnect}
+        onPaneContextMenu={(e) => { e.preventDefault(); setContextMenu({ x: e.clientX, y: e.clientY }) }}
+        className="bg-background"
+        fitView
+      >
+        <Background />
+        <Controls />
+      </ReactFlow>
+      {contextMenu && (
+        <NodeContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          nodeId={contextMenu.nodeId}
+          edgeId={contextMenu.edgeId}
+          onCreateNode={() => {}}
+          onDeleteNode={(nid) => { handleDeleteNode(nid || contextMenu.nodeId); setContextMenu(null) }}
+          onEditNode={(nid) => { handleEditNode(nid || contextMenu.nodeId); setContextMenu(null) }}
+          onUnlinkEdge={(eid) => { handleUnlinkEdge(eid || contextMenu.edgeId); setContextMenu(null) }}
+          onClose={() => setContextMenu(null)}
+          onExportMapAsPng={exportMapAsPng}
+        />
+      )}
+    </div>
+  )
+}
+
+

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useProjectStore } from '../store/projectStore'
 import { useTabStore } from '../store/tabStore'
 import { useGroupViewStore } from '../store/groupViewState'
@@ -27,6 +27,7 @@ export default function GroupView() {
   const setBoxLayout = useGroupViewStore(s => s.setBoxLayout)
   const { nodes: verbweaverNodes, deleteNode, createSoftLink, removeSoftLink } = useNodeStore()
   const { addEditorTab } = useTabStore()
+  const flowWrapperRef = useRef<HTMLDivElement>(null)
 
   // Check if we're in Electron
   const isElectron = typeof window !== 'undefined' && (window as any).electronAPI !== undefined
@@ -461,11 +462,205 @@ export default function GroupView() {
   }, [setBoxLayout, saveToStorage, tabs, activeTabId, currentProject?.id])
 
   const exportMapAsPng = useCallback(async () => {
+    const toHide: HTMLElement[] = []
+    const styled: Array<{ el: HTMLElement; prev: { color?: string; backgroundColor?: string; fill?: string; stroke?: string } }> = []
+    const imageEvents: Array<{ src: string; ok: boolean; error?: any }> = []
+    const originalImage = window.Image
     try {
-      const el = document.querySelector('.react-flow__renderer') as HTMLElement
-      const viewport = document.querySelector('.react-flow') as HTMLElement
-      const target = el || viewport || document.body
-      const dataUrl = await htmlToImage.toPng(target, { backgroundColor: getComputedStyle(document.body).getPropertyValue('--background') || '#fff' })
+      // Patch Image to log every load/error that html-to-image triggers
+      // so we can deterministically see failing resources.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      window.Image = class LoggingImage extends originalImage {
+        constructor() {
+          super()
+          this.crossOrigin = 'anonymous'
+          this.addEventListener('load', () => { imageEvents.push({ src: (this as any).src || '', ok: true }) })
+          this.addEventListener('error', (err) => { imageEvents.push({ src: (this as any).src || '', ok: false, error: err }) })
+        }
+      } as typeof Image
+
+      const wrapper = flowWrapperRef.current
+      const flowRoot = (wrapper?.querySelector('.react-flow__renderer') as HTMLElement | null) || (wrapper?.querySelector('.react-flow') as HTMLElement | null)
+      if (!flowRoot) {
+        toast.error('Could not find the group canvas to export')
+        return
+      }
+
+      // Collect all candidate resource URLs before capture to detect failures deterministically
+      const collectResourceUrls = (root: HTMLElement) => {
+        const urls = new Set<string>()
+        root.querySelectorAll('img').forEach(img => { if (img.src) urls.add(img.src) })
+        root.querySelectorAll<HTMLElement>('*').forEach(el => {
+          const bg = getComputedStyle(el).backgroundImage || ''
+          // Match url("...") occurrences; may return multiple
+          const matches = Array.from(bg.matchAll(/url\(["']?([^"')]+)["']?\)/g))
+          matches.forEach(m => { if (m[1]) urls.add(m[1]) })
+        })
+        return Array.from(urls)
+      }
+
+      const preflightResources = async (urls: string[]) => {
+        const checks = urls.map(url => new Promise<{ url: string; ok: boolean; error?: any }>(resolve => {
+          const img = new Image()
+          img.crossOrigin = 'anonymous'
+          img.onload = () => resolve({ url, ok: true })
+          img.onerror = (err) => resolve({ url, ok: false, error: err })
+          img.src = url
+        }))
+        return Promise.all(checks)
+      }
+
+      const resourceUrls = collectResourceUrls(flowRoot)
+      console.log('[Group export] resources detected', resourceUrls)
+      const preflight = await preflightResources(resourceUrls)
+      const failed = preflight.filter(r => !r.ok)
+      console.log('[Group export] preflight results', preflight)
+      if (failed.length) {
+        console.error('Group export preflight failed for URLs:', failed)
+        toast.error('Failed to export map: resource could not be loaded')
+        return
+      }
+
+      wrapper?.querySelectorAll('.react-flow__attribution, .react-flow__controls, .vw-node-context-menu').forEach(el => {
+        const h = el as HTMLElement
+        if (h.style) { toHide.push(h); h.style.visibility = 'hidden' }
+      })
+
+      // Inline edge label colors to avoid missing computed styles in export
+      flowRoot.querySelectorAll('.react-flow__edge-textbg').forEach(el => {
+        const h = el as HTMLElement
+        const cs = getComputedStyle(h)
+        const prev = { backgroundColor: h.style.backgroundColor, fill: (h.style as any).fill, stroke: (h.style as any).stroke }
+        const fill = cs.fill || cs.backgroundColor
+        const stroke = (cs as any).stroke || cs.borderColor
+        if (fill) (h.style as any).fill = fill
+        if (stroke) (h.style as any).stroke = stroke
+        styled.push({ el: h, prev })
+      })
+      flowRoot.querySelectorAll('.react-flow__edge-text').forEach(el => {
+        const h = el as HTMLElement
+        const cs = getComputedStyle(h)
+        const prev = { color: h.style.color, fill: (h.style as any).fill }
+        const textFill = (cs as any).fill && (cs as any).fill !== 'none' ? (cs as any).fill : cs.color
+        if (textFill) (h.style as any).fill = textFill
+        h.style.color = textFill
+        styled.push({ el: h, prev })
+      })
+
+      const root = getComputedStyle(document.documentElement)
+      const bgVar = root.getPropertyValue('--background').trim()
+      const bgColor = bgVar ? `hsl(${bgVar})` : getComputedStyle(document.body).backgroundColor || '#fff'
+
+      // First generate SVG so we can inspect it deterministically
+      const svgDataUrl = await htmlToImage.toSvg(flowRoot, {
+        backgroundColor: bgColor,
+        pixelRatio: window.devicePixelRatio || 1,
+        cacheBust: true,
+        useCORS: true,
+        filter: (el: Element) => {
+          const cls = (el as HTMLElement).classList
+          if (!cls) return true
+          return !cls.contains('react-flow__controls') && !cls.contains('react-flow__attribution') && !cls.contains('vw-node-context-menu')
+        },
+      })
+
+      let svgText = (() => {
+        try {
+          const comma = svgDataUrl.indexOf(',')
+          return comma >= 0 ? decodeURIComponent(svgDataUrl.slice(comma + 1)) : ''
+        } catch {
+          return ''
+        }
+      })()
+      console.log('[Group export] svg length', svgText?.length || 0)
+      if (svgText) {
+        console.log('[Group export] svg head', svgText.slice(0, 400))
+        console.log('[Group export] svg tail', svgText.slice(-400))
+      }
+
+      // Validate SVG parse to surface syntax errors
+      const parser = new DOMParser()
+      const parsed = parser.parseFromString(svgText, 'image/svg+xml')
+      let parseError = parsed.querySelector('parsererror')
+      if (parseError) {
+        const msg = parseError.textContent || ''
+        const colMatch = msg.match(/column\s+(\d+)/i)
+        const col = colMatch ? Number(colMatch[1]) : -1
+        const charInfo = () => {
+          if (col <= 0 || col > svgText.length) return null
+          const idx = col - 1
+          const ch = svgText[idx]
+          const code = ch ? ch.charCodeAt(0) : -1
+          return { idx, ch, code, context: svgText.slice(Math.max(0, idx - 40), Math.min(svgText.length, idx + 40)) }
+        }
+        console.error('Group export: SVG parsererror', msg, { column: col, charInfo: charInfo() })
+
+        // Sanitize control characters not allowed in XML and retry
+        const sanitized = svgText.replace(/[^\t\n\r\u0020-\uD7FF\uE000-\uFFFD]/g, '')
+        if (sanitized !== svgText) {
+          const reparsed = parser.parseFromString(sanitized, 'image/svg+xml')
+          const reparsedError = reparsed.querySelector('parsererror')
+          if (!reparsedError) {
+            console.warn('Group export: SVG sanitized to remove invalid chars before export')
+            svgText = sanitized
+            parseError = null
+          } else {
+            console.error('Group export: SVG still invalid after sanitize', reparsedError.textContent)
+          }
+        }
+        if (parseError) {
+          toast.error('Failed to export map: invalid SVG (see console)')
+          return
+        }
+      }
+
+      // Normalize to base64 data URL to eliminate encoding edge cases
+      const svgBase64 = (() => {
+        try {
+          return `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgText)))}`
+        } catch (err) {
+          console.error('Group export: base64 encode failed', err)
+          return svgDataUrl
+        }
+      })()
+
+      // Manual image load to surface the exact error if decode fails
+      const imgResult = await new Promise<{ ok: true; w: number; h: number } | { ok: false; error: any }>((resolve) => {
+        const img = new Image()
+        img.crossOrigin = 'anonymous'
+        img.onload = () => resolve({ ok: true, w: img.naturalWidth, h: img.naturalHeight })
+        img.onerror = (err) => resolve({ ok: false, error: err })
+        img.src = svgBase64
+      })
+
+      if (!imgResult.ok) {
+        console.error('Group export: SVG image decode failed', imgResult, { svgSample: svgText?.slice(0, 500) })
+        toast.error('Failed to export map: SVG decode error (see console)')
+        return
+      }
+
+      // Draw to canvas manually to avoid hidden internals masking errors
+      const canvas = document.createElement('canvas')
+      canvas.width = imgResult.w
+      canvas.height = imgResult.h
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        toast.error('Failed to export map: no canvas context')
+        return
+      }
+      // Paint background first for safety
+      ctx.fillStyle = bgColor
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+      ctx.drawImage(await (() => new Promise<HTMLImageElement>((resolve, reject) => {
+        const img = new Image()
+        img.crossOrigin = 'anonymous'
+        img.onload = () => resolve(img)
+        img.onerror = reject
+        img.src = svgBase64
+      }))(), 0, 0)
+
+      const dataUrl = canvas.toDataURL('image/png')
       const filename = `groups-${new Date().toISOString().replace(/[:.]/g,'-')}.png`
       if (isElectron && (window as any).electronAPI?.saveBinaryFile) {
         const bin = await (await fetch(dataUrl)).arrayBuffer()
@@ -480,9 +675,33 @@ export default function GroupView() {
         link.remove()
         toast.success('Download started')
       }
+      ;(window as any).__vw_groupExportDebug = {
+        svgLength: svgText?.length || 0,
+        svgSampleHead: svgText?.slice(0, 400),
+        svgSampleTail: svgText?.slice(-400),
+        resourceUrls,
+        preflight,
+        imageEvents,
+        svgParseError: parseError?.textContent || null,
+        svgDataUrl: svgDataUrl?.slice(0, 200) || '',
+        svgBase64Prefix: svgBase64?.slice(0, 200) || '',
+      }
     } catch (e) {
-      toast.error('Failed to export map')
+      console.error('Failed to export group map:', e, { imageEvents })
+      const msg = e && (e as Error).message ? (e as Error).message : ''
+      toast.error(`Failed to export map${msg ? `: ${msg}` : ''}`)
     } finally {
+      try { window.Image = originalImage } catch {}
+      try { console.log('[Group export] image load events', imageEvents) } catch {}
+      try { toHide.forEach(h => { h.style.visibility = '' }) } catch {}
+      try {
+        styled.forEach(s => {
+          if (s.prev.color !== undefined) s.el.style.color = s.prev.color
+          if (s.prev.backgroundColor !== undefined) s.el.style.backgroundColor = s.prev.backgroundColor
+          if ((s.prev as any).fill !== undefined) (s.el.style as any).fill = (s.prev as any).fill
+          if ((s.prev as any).stroke !== undefined) (s.el.style as any).stroke = (s.prev as any).stroke
+        })
+      } catch {}
       setContextMenu(null)
     }
   }, [isElectron])
@@ -566,7 +785,7 @@ export default function GroupView() {
   }, [idToPath, createSoftLink])
 
   return (
-    <div className="h-full w-full">
+    <div ref={flowWrapperRef} className="h-full w-full">
       <ReactFlow
         nodes={flowNodes}
         edges={renderEdges}
@@ -590,6 +809,7 @@ export default function GroupView() {
           y={contextMenu.y}
           nodeId={contextMenu.nodeId}
           edgeId={contextMenu.edgeId}
+          variant={!contextMenu.nodeId && !contextMenu.edgeId ? 'group-pane' : undefined}
           onCreateNode={() => {}}
           onDeleteNode={(nid) => { handleDeleteNode(nid || contextMenu.nodeId); setContextMenu(null) }}
           onEditNode={(nid) => { handleEditNode(nid || contextMenu.nodeId); setContextMenu(null) }}

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -3,7 +3,7 @@ import { useProjectStore } from '../store/projectStore'
 import { useTabStore } from '../store/tabStore'
 import { useGroupViewStore } from '../store/groupViewState'
 import { useNodeStore } from '../store/nodeStore'
-import ReactFlow, { Background, Controls, Edge, Node, NodeTypes, useEdgesState, useNodesState, Connection } from 'react-flow-renderer'
+import ReactFlow, { Background, Controls, Edge, Node, NodeTypes, Connection } from 'react-flow-renderer'
 import { buildEquivalenceBoxes, computeCoverRelations, computeRemainder } from '../utils/grouping'
 import NodeContextMenu from '../components/graph/NodeContextMenu'
 // @ts-ignore: type stub provided in global.d.ts; package installed at runtime
@@ -155,6 +155,12 @@ export default function GroupView() {
     const boxIdToName = new Map<string, string>(
       equivalence.boxes.map(b => [b.boxId, b.groupIds.map(id => equivalence.byId.get(id)?.name || id).join(', ')])
     )
+    const safeIdByBoxId = new Map<string, string>()
+    equivalence.boxes.forEach((b, i) => {
+      const sid = b.boxId && b.boxId.length > 0 ? b.boxId : `__empty__${i}`
+      safeIdByBoxId.set(b.boxId, sid)
+    })
+    
 
     // Simple grid for initial positions if not saved
     const gridW = 260, gridH = 140, perRow = 3
@@ -196,8 +202,9 @@ export default function GroupView() {
           const rows = Math.ceil(Math.min(totalCount, maxCards) / columns)
           return 28 + rows * (80 + 12) + 24
         }
+        const sid = safeIdByBoxId.get(b.boxId)!
         nodes.push({
-          id: b.boxId,
+          id: sid,
           data: { label: boxIdToName.get(b.boxId) || 'Group', isEquivalent: isEq, chips: chipsFor(b.nodeIds), linkPairs: linkPairsFor(b.nodeIds), showNodeCards: !!options.showNodeCards, visibleCardCount: Math.min(totalCount, maxCards), totalCardCount: totalCount, showCapIndicator: showCap },
           position: { x, y },
           style: { width: boxWidth, height: estimateHeight() },
@@ -221,8 +228,8 @@ export default function GroupView() {
             const path = idToPath.get(cid)
             const storeNode = path ? verbweaverNodes.get(path) : undefined
             nodes.push({
-              id: `${b.boxId}::n::${cid}`,
-              parentNode: b.boxId,
+              id: `${sid}::n::${cid}`,
+              parentNode: sid,
               position: { x: cx, y: cy },
               type: 'custom',
               draggable: false,
@@ -241,11 +248,13 @@ export default function GroupView() {
             links.forEach(to => {
               if (idSet.has(String(to))) {
                 edges.push({
-                  id: `${b.boxId}::e::${from}->${to}`,
-                  source: `${b.boxId}::n::${from}`,
-                  target: `${b.boxId}::n::${to}`,
+                  id: `${sid}::e::${from}->${to}`,
+                  source: `${sid}::n::${from}`,
+                  target: `${sid}::n::${to}`,
                   type: 'default',
-                })
+                  sourceHandle: 'right-source',
+                  targetHandle: 'left-target',
+                } as any)
               }
             })
           })
@@ -253,15 +262,18 @@ export default function GroupView() {
       })
       // Flat mode: edges for superset/subset cover relations
       covers.forEach(e => {
-        edges.push({ id: `${e.parentBoxId}->${e.childBoxId}`, source: e.parentBoxId, target: e.childBoxId })
+        const ps = safeIdByBoxId.get(e.parentBoxId)!
+        const cs = safeIdByBoxId.get(e.childBoxId)!
+        if (ps && cs) edges.push({ id: `${ps}->${cs}`, source: ps, target: cs })
       })
     } else {
       // Nesting mode: recursively place children under each parent; duplicate children under multiple parents
-      const placeBox = (boxId: string, parent?: string, depth: number = 0, idx: number = 0) => {
+      const placeBox = (boxId: string, parentSafeId?: string, depth: number = 0, idx: number = 0) => {
         const b = equivalence.boxes.find(x => x.boxId === boxId)
         if (!b) return
-        const baseId = parent ? `${boxId}__under__${parent}` : boxId
-        const saved = layout.boxes[baseId] || layout.boxes[boxId]
+        const safe = safeIdByBoxId.get(boxId)!
+        const baseId = parentSafeId ? `${safe}__under__${parentSafeId}` : safe
+        const saved = layout.boxes[baseId] || layout.boxes[safe] || layout.boxes[boxId]
         const x = saved?.x ?? ((idx % perRow) * gridW + depth * 12)
         const y = saved?.y ?? (Math.floor(idx / perRow) * gridH)
         const isEq = b.groupIds.length > 1
@@ -272,16 +284,16 @@ export default function GroupView() {
           const cb = equivalence.boxes.find(x => x.boxId === cid)
           return cb ? cb.nodeIds : []
         })) : b.nodeIds
-        const isRoot = !parent
+        const isRoot = !parentSafeId
         const displayedSet = isRoot ? remainder : b.nodeIds
         const totalCount = displayedSet.length
 
         // Estimate height and width
-        const boxWidth = options.showNodeCards ? (parent ? 480 : 520) : (parent ? 240 : 260)
+        const boxWidth = options.showNodeCards ? (parentSafeId ? 480 : 520) : (parentSafeId ? 240 : 260)
         const columns = options.showNodeCards ? (boxWidth >= 520 ? 3 : 2) : 0
         const estimateHeight = () => {
           if (!options.showNodeCards) return 160
-          const count = (parent ? b.nodeIds : remainder).length
+          const count = (parentSafeId ? b.nodeIds : remainder).length
           const rows = Math.ceil(Math.min(count, maxCards) / columns)
           return 28 + rows * (80 + 12) + 24
         }
@@ -302,15 +314,15 @@ export default function GroupView() {
           position: { x, y },
           style: { width: boxWidth, height: estimateHeight() },
           type: 'groupBox',
-          draggable: !parent,
-          parentNode: parent,
-          extent: parent ? 'parent' : undefined,
+          draggable: !parentSafeId,
+          parentNode: parentSafeId,
+          extent: parentSafeId ? 'parent' : undefined,
         } as any)
 
         // In nested mode with node cards, render only remainder nodes inside the parent box;
         // child boxes will render their own nodes.
         if (options.showNodeCards) {
-          const childIds = (parent ? b.nodeIds : remainder).slice(0, maxCards)
+          const childIds = (parentSafeId ? b.nodeIds : remainder).slice(0, maxCards)
           const columns = (boxWidth >= 520 ? 3 : 2)
           const cardW = 180
           const cardH = 80
@@ -348,7 +360,9 @@ export default function GroupView() {
                   source: `${baseId}::n::${from}`,
                   target: `${baseId}::n::${to}`,
                   type: 'default',
-                })
+                  sourceHandle: 'right-source',
+                  targetHandle: 'left-target',
+                } as any)
               }
             })
           })
@@ -364,12 +378,21 @@ export default function GroupView() {
     return { flowNodes: nodes, flowEdges: edges }
   }, [equivalence, layout.boxes, options.nestGroups, options.showNodeCards, idToMeta])
 
-  const [nodesState, setNodesState, onNodesChange] = useNodesState(flowNodes)
-  const [edgesState, setEdgesState, onEdgesChange] = useEdgesState(flowEdges)
+  const [optimisticEdges, setOptimisticEdges] = useState<Edge[]>([])
+  const renderEdges = useMemo(() => {
+    if (!optimisticEdges.length) return flowEdges
+    const exist = new Set(flowEdges.map(e => e.id))
+    const extras = optimisticEdges.filter(e => !exist.has(e.id))
+    return [...flowEdges, ...extras]
+  }, [flowEdges, optimisticEdges])
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId?: string; edgeId?: string } | null>(null)
 
-  useEffect(() => { setNodesState(flowNodes) }, [flowNodes, setNodesState])
-  useEffect(() => { setEdgesState(flowEdges) }, [flowEdges, setEdgesState])
+  // Clear optimistic edges that are now part of computed edges
+  useEffect(() => {
+    if (!optimisticEdges.length) return
+    const exist = new Set(flowEdges.map(e => e.id))
+    setOptimisticEdges(prev => prev.filter(e => !exist.has(e.id)))
+  }, [flowEdges])
 
   const onNodeDragStop = useCallback((_: any, n: Node) => {
     if (!n?.id) return
@@ -458,9 +481,9 @@ export default function GroupView() {
     const toPath = idToPath.get(to)
     if (fromPath && toPath) {
       await removeSoftLink(fromPath, toPath)
-      setEdgesState(prev => prev.filter(e => e.id !== edgeId))
+      setOptimisticEdges(prev => prev.filter(e => e.id !== edgeId))
     }
-  }, [idToPath, removeSoftLink, setEdgesState])
+  }, [idToPath, removeSoftLink])
 
   const onConnect = useCallback(async (conn: Connection) => {
     const getUnderlying = (nid?: string | null) => (nid ? parseUnderlyingId(nid) : null)
@@ -475,59 +498,48 @@ export default function GroupView() {
       const base = (nid: string) => nid.split('::n::')[0]
       if (base(conn.source!) === base(conn.target!)) {
         const baseId = base(conn.source!)
-        setEdgesState(prev => ([...prev, { id: `${baseId}::e::${s}->${t}`, source: `${baseId}::n::${s}`, target: `${baseId}::n::${t}` }]))
+        setOptimisticEdges(prev => ([...prev, {
+          id: `${baseId}::e::${s}->${t}`,
+          source: `${baseId}::n::${s}`,
+          target: `${baseId}::n::${t}`,
+          sourceHandle: conn.sourceHandle || 'right-source',
+          targetHandle: conn.targetHandle || 'left-target',
+        } as any]))
       }
     }
-  }, [idToPath, createSoftLink, setEdgesState])
+  }, [idToPath, createSoftLink])
 
   const performAutoLayout = useCallback(() => {
     if (!options.nestGroups) {
       // Flat mode: layout group boxes using dagre; keep children relative
-      const groupNodes = nodesState.filter(n => n.type === 'groupBox')
-      const groupEdges = edgesState.filter(e => !String(e.id).includes('::e::'))
+      const groupNodes = flowNodes.filter(n => n.type === 'groupBox')
+      const groupEdges = flowEdges.filter(e => !String(e.id).includes('::e::'))
       const { nodes: laid } = getLayoutedElements(groupNodes as any, groupEdges as any, { direction: 'TB', nodeSpacing: 160, rankSpacing: 200 })
-      laid.forEach(n => setBoxLayout(n.id, { x: n.position.x, y: n.position.y, w: n.width, h: n.height }))
-      setNodesState(prev => prev.map(n => {
-        const found = laid.find(m => m.id === n.id)
-        return found ? { ...n, position: found.position } : n
-      }))
+      laid.forEach(n => setBoxLayout(n.id, { x: (n as any).position.x, y: (n as any).position.y, w: (n as any).width, h: (n as any).height }))
     } else {
       // Nest mode: simple packing - stack child boxes vertically within each parent
-      const updated: Record<string, { x: number; y: number }> = {}
-      const groups = nodesState.filter(n => n.type === 'groupBox')
+      const groups = flowNodes.filter(n => n.type === 'groupBox')
       const roots = groups.filter(n => !n.parentNode)
-      const getWidth = (nId: string) => {
-        const n = nodesState.find(m => m.id === nId)
+      const widthOf = (nId: string) => {
+        const n = groups.find(m => m.id === nId)
         const w = n && n.style && (n.style as any).width ? Number((n.style as any).width) : (options.showNodeCards ? 520 : 260)
         return Number.isFinite(w) ? w : (options.showNodeCards ? 520 : 260)
       }
       const placeChildren = (parentId: string) => {
         const children = groups.filter(n => n.parentNode === parentId)
         let y = 28
-        const parentW = getWidth(parentId)
-        children.forEach((c, idx) => {
-          const childW = getWidth(c.id)
+        const parentW = widthOf(parentId)
+        children.forEach(c => {
+          const childW = widthOf(c.id)
           const x = Math.max(16, Math.round((parentW - childW) / 2))
-          updated[c.id] = { x, y }
+          setBoxLayout(c.id, { x, y })
           y += (c.style && (c.style as any).height ? Number((c.style as any).height) : 160) + 16
-          // Recurse
           placeChildren(c.id)
         })
       }
       roots.forEach(r => placeChildren(r.id))
-      // Apply child positions relative to parent and expand parent size
-      setNodesState(prev => prev.map(n => {
-        if (updated[n.id]) {
-          return { ...n, position: updated[n.id] }
-        }
-        if (!n.parentNode && n.type === 'groupBox') {
-          // expand root boxes to fit children roughly
-          return { ...n, style: { ...(n.style || {}), width: 520, height: 400 } }
-        }
-        return n
-      }))
     }
-  }, [options.nestGroups, nodesState, edgesState, setNodesState, setBoxLayout])
+  }, [options.nestGroups, options.showNodeCards, flowNodes, flowEdges, setBoxLayout])
 
   // Trigger auto layout via Options tray button
   const layoutVersion = useGroupViewStore(s => s.layoutVersion)
@@ -539,11 +551,11 @@ export default function GroupView() {
   return (
     <div className="h-full w-full">
       <ReactFlow
-        nodes={nodesState}
-        edges={edgesState}
+        nodes={flowNodes}
+        edges={renderEdges}
         nodeTypes={groupNodeTypes}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
+        onNodesChange={undefined as any}
+        onEdgesChange={undefined as any}
         onNodeDragStop={onNodeDragStop}
         onNodeContextMenu={onNodeContextMenu}
         onEdgeContextMenu={onEdgeContextMenu}

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -463,9 +463,10 @@ export default function GroupView() {
 
   const exportMapAsPng = useCallback(async () => {
     const toHide: HTMLElement[] = []
-    const styled: Array<{ el: HTMLElement; prev: { color?: string; backgroundColor?: string; fill?: string; stroke?: string } }> = []
+    const styled: Array<{ el: HTMLElement; prev: { color?: string; backgroundColor?: string; fill?: string; stroke?: string; strokeWidth?: string } }> = []
     const imageEvents: Array<{ src: string; ok: boolean; error?: any }> = []
     const originalImage = window.Image
+    const scrubbedAttrs: Array<{ el: Element; name: string; prev: string }> = []
     try {
       // Patch Image to log every load/error that html-to-image triggers
       // so we can deterministically see failing resources.
@@ -481,7 +482,7 @@ export default function GroupView() {
       } as typeof Image
 
       const wrapper = flowWrapperRef.current
-      const flowRoot = (wrapper?.querySelector('.react-flow__renderer') as HTMLElement | null) || (wrapper?.querySelector('.react-flow') as HTMLElement | null)
+      const flowRoot = (wrapper?.querySelector('.react-flow') as HTMLElement | null) || (wrapper?.querySelector('.react-flow__renderer') as HTMLElement | null)
       if (!flowRoot) {
         toast.error('Could not find the group canvas to export')
         return
@@ -527,6 +528,45 @@ export default function GroupView() {
         if (h.style) { toHide.push(h); h.style.visibility = 'hidden' }
       })
 
+      // Scrub invalid XML chars from attribute values to avoid parser errors in toSvg
+      const invalidXmlChars = /[^\t\n\r\u0020-\uD7FF\uE000-\uFFFD]/g
+      const scrubElementAttributes = (el: Element) => {
+        if (el.attributes) {
+          Array.from(el.attributes).forEach(attr => {
+            if (invalidXmlChars.test(attr.value)) {
+              scrubbedAttrs.push({ el, name: attr.name, prev: attr.value })
+              attr.value = attr.value.replace(invalidXmlChars, '')
+            }
+          })
+        }
+        Array.from(el.children || []).forEach(child => scrubElementAttributes(child))
+      }
+      scrubElementAttributes(flowRoot)
+
+      // Inline edge stroke styles so edges render in exported image
+      flowRoot.querySelectorAll('.react-flow__edge-path, .react-flow__connection-path').forEach(el => {
+        try {
+          const h = el as HTMLElement
+          const cs = getComputedStyle(h)
+          const prev = {
+            stroke: (h.style as any).stroke,
+            strokeWidth: (h.style as any).strokeWidth,
+            fill: (h.style as any).fill,
+            attrStroke: h.getAttribute('stroke'),
+            attrStrokeWidth: h.getAttribute('stroke-width'),
+            attrFill: h.getAttribute('fill'),
+          }
+          const stroke = cs.getPropertyValue('stroke') || '#9ca3af'
+          const strokeWidth = cs.getPropertyValue('stroke-width') || '3'
+          h.setAttribute('stroke', stroke)
+          h.setAttribute('stroke-width', strokeWidth)
+          h.setAttribute('fill', 'none')
+          styled.push({ el: h, prev })
+        } catch (err) {
+          console.error('Group export: failed to inline edge stroke', err, { el })
+        }
+      })
+
       // Inline edge label colors to avoid missing computed styles in export
       flowRoot.querySelectorAll('.react-flow__edge-textbg').forEach(el => {
         const h = el as HTMLElement
@@ -557,13 +597,14 @@ export default function GroupView() {
         backgroundColor: bgColor,
         pixelRatio: window.devicePixelRatio || 1,
         cacheBust: true,
+        // useCORS is supported at runtime; cast to satisfy types
         useCORS: true,
         filter: (el: Element) => {
           const cls = (el as HTMLElement).classList
           if (!cls) return true
           return !cls.contains('react-flow__controls') && !cls.contains('react-flow__attribution') && !cls.contains('vw-node-context-menu')
         },
-      })
+      } as any)
 
       let svgText = (() => {
         try {
@@ -583,8 +624,10 @@ export default function GroupView() {
       const parser = new DOMParser()
       const parsed = parser.parseFromString(svgText, 'image/svg+xml')
       let parseError = parsed.querySelector('parsererror')
+      let parseErrorText: string | null = null
       if (parseError) {
         const msg = parseError.textContent || ''
+        parseErrorText = msg
         const colMatch = msg.match(/column\s+(\d+)/i)
         const col = colMatch ? Number(colMatch[1]) : -1
         const charInfo = () => {
@@ -682,7 +725,7 @@ export default function GroupView() {
         resourceUrls,
         preflight,
         imageEvents,
-        svgParseError: parseError?.textContent || null,
+        svgParseError: parseErrorText,
         svgDataUrl: svgDataUrl?.slice(0, 200) || '',
         svgBase64Prefix: svgBase64?.slice(0, 200) || '',
       }
@@ -694,12 +737,17 @@ export default function GroupView() {
       try { window.Image = originalImage } catch {}
       try { console.log('[Group export] image load events', imageEvents) } catch {}
       try { toHide.forEach(h => { h.style.visibility = '' }) } catch {}
+      try { scrubbedAttrs.forEach(s => { s.el.setAttribute(s.name, s.prev) }) } catch {}
       try {
         styled.forEach(s => {
           if (s.prev.color !== undefined) s.el.style.color = s.prev.color
           if (s.prev.backgroundColor !== undefined) s.el.style.backgroundColor = s.prev.backgroundColor
           if ((s.prev as any).fill !== undefined) (s.el.style as any).fill = (s.prev as any).fill
           if ((s.prev as any).stroke !== undefined) (s.el.style as any).stroke = (s.prev as any).stroke
+          if ((s.prev as any).strokeWidth !== undefined) (s.el.style as any).strokeWidth = (s.prev as any).strokeWidth
+          if ((s.prev as any).attrStroke !== undefined && (s.prev as any).attrStroke !== null) s.el.setAttribute('stroke', (s.prev as any).attrStroke)
+          if ((s.prev as any).attrStrokeWidth !== undefined && (s.prev as any).attrStrokeWidth !== null) s.el.setAttribute('stroke-width', (s.prev as any).attrStrokeWidth)
+          if ((s.prev as any).attrFill !== undefined && (s.prev as any).attrFill !== null) s.el.setAttribute('fill', (s.prev as any).attrFill)
         })
       } catch {}
       setContextMenu(null)

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -263,7 +263,16 @@ export default function GroupView() {
       covers.forEach(e => {
         const ps = safeIdByBoxId.get(e.parentBoxId)!
         const cs = safeIdByBoxId.get(e.childBoxId)!
-        if (ps && cs) edges.push({ id: `${ps}->${cs}`, source: ps, target: cs })
+        if (ps && cs) edges.push({
+          id: `${ps}->${cs}`,
+          source: ps,
+          target: cs,
+          label: 'Contains',
+          labelStyle: { fontSize: 11, fontWeight: 500, fill: 'hsl(var(--muted-foreground))' },
+          labelBgStyle: { fill: 'hsl(var(--background))', fillOpacity: 0.9 },
+          labelBgPadding: [4, 2] as [number, number],
+          labelBgBorderRadius: 3,
+        })
       })
     } else {
       // Nesting mode: recursively place children under each parent; duplicate children under multiple parents

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -412,7 +412,7 @@ export default function GroupView() {
     }
 
     return { flowNodes: nodes, flowEdges: edges }
-  }, [equivalence, layout.boxes, options.nestGroups, options.showNodeCards, idToMeta])
+  }, [equivalence, layout.boxes, options.nestGroups, options.showNodeCards, options.maxCardsPerGroup, options.showCapIndicator, idToMeta])
 
   const [optimisticEdges, setOptimisticEdges] = useState<Edge[]>([])
   const renderEdges = useMemo(() => {

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -380,11 +380,22 @@ export default function GroupView() {
 
   const [optimisticEdges, setOptimisticEdges] = useState<Edge[]>([])
   const renderEdges = useMemo(() => {
-    if (!optimisticEdges.length) return flowEdges
-    const exist = new Set(flowEdges.map(e => e.id))
-    const extras = optimisticEdges.filter(e => !exist.has(e.id))
-    return [...flowEdges, ...extras]
-  }, [flowEdges, optimisticEdges])
+    const nodeIds = new Set(flowNodes.map(n => n.id))
+    const baseEdges = options.nestGroups
+      ? flowEdges.filter(e => e.id.includes('::e::') || (String(e.source).includes('::n::') && String(e.target).includes('::n::')))
+      : flowEdges
+    const exist = new Set(baseEdges.map(e => e.id))
+    const extras = optimisticEdges
+      .filter(e => !exist.has(e.id))
+      .filter(e => nodeIds.has(e.source) && nodeIds.has(e.target))
+      .filter(e => !options.nestGroups || e.id.includes('::e::') || (String(e.source).includes('::n::') && String(e.target).includes('::n::')))
+    return [...baseEdges, ...extras]
+  }, [flowEdges, optimisticEdges, flowNodes, options.nestGroups])
+
+  // Clear optimistic edges when toggling nest mode to avoid stale group-to-group edges with missing handles
+  useEffect(() => {
+    setOptimisticEdges([])
+  }, [options.nestGroups])
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId?: string; edgeId?: string } | null>(null)
 
   // Clear optimistic edges that are now part of computed edges
@@ -396,7 +407,7 @@ export default function GroupView() {
 
   const onNodeDragStop = useCallback((_: any, n: Node) => {
     if (!n?.id) return
-    setBoxLayout(n.id, { x: n.position.x, y: n.position.y, w: n.width, h: n.height })
+    setBoxLayout(n.id, { x: n.position.x, y: n.position.y, w: n.width ?? undefined, h: n.height ?? undefined })
     const tab = tabs.find(t => t.id === activeTabId)
     const graphTabId = tab && tab.type === 'graph' ? tab.id : undefined
     if (currentProject?.id && graphTabId) {

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -3,7 +3,7 @@ import { useProjectStore } from '../store/projectStore'
 import { useTabStore } from '../store/tabStore'
 import { useGroupViewStore } from '../store/groupViewState'
 import { useNodeStore } from '../store/nodeStore'
-import ReactFlow, { Background, Controls, Edge, Node, NodeTypes, Connection } from 'react-flow-renderer'
+import ReactFlow, { Background, Controls, Edge, Node, NodeTypes, Connection, useReactFlow } from 'react-flow-renderer'
 import { buildEquivalenceBoxes, computeCoverRelations, computeRemainder } from '../utils/grouping'
 import NodeContextMenu from '../components/graph/NodeContextMenu'
 // @ts-ignore: type stub provided in global.d.ts; package installed at runtime
@@ -28,6 +28,7 @@ export default function GroupView() {
   const { nodes: verbweaverNodes, deleteNode, createSoftLink, removeSoftLink } = useNodeStore()
   const { addEditorTab } = useTabStore()
   const flowWrapperRef = useRef<HTMLDivElement>(null)
+  const { fitView, getViewport, setViewport } = useReactFlow()
 
   // Check if we're in Electron
   const isElectron = typeof window !== 'undefined' && (window as any).electronAPI !== undefined
@@ -523,6 +524,16 @@ export default function GroupView() {
         return
       }
 
+      // Fit all nodes into view for export, then restore the viewport afterward
+      const prevViewport = getViewport ? getViewport() : null
+      try {
+        if (flowNodes.length > 0 && fitView) {
+          await Promise.resolve(fitView({ includeHiddenNodes: true, padding: 0.2 }))
+        }
+      } catch (err) {
+        console.error('Group export: fitView failed (continuing)', err)
+      }
+
       wrapper?.querySelectorAll('.react-flow__attribution, .react-flow__controls, .vw-node-context-menu').forEach(el => {
         const h = el as HTMLElement
         if (h.style) { toHide.push(h); h.style.visibility = 'hidden' }
@@ -750,9 +761,14 @@ export default function GroupView() {
           if ((s.prev as any).attrFill !== undefined && (s.prev as any).attrFill !== null) s.el.setAttribute('fill', (s.prev as any).attrFill)
         })
       } catch {}
+      try {
+        if (prevViewport && setViewport) {
+          setViewport(prevViewport)
+        }
+      } catch {}
       setContextMenu(null)
     }
-  }, [isElectron])
+  }, [isElectron, flowNodes.length, fitView, getViewport, setViewport])
 
   const parseUnderlyingId = (nodeId: string): string | null => {
     const marker = '::n::'

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -3,7 +3,7 @@ import { useProjectStore } from '../store/projectStore'
 import { useTabStore } from '../store/tabStore'
 import { useGroupViewStore } from '../store/groupViewState'
 import { useNodeStore } from '../store/nodeStore'
-import ReactFlow, { Background, Controls, Edge, Node, NodeTypes, Connection, useReactFlow } from 'react-flow-renderer'
+import ReactFlow, { Background, Controls, Edge, Node, NodeTypes, Connection, useReactFlow, ReactFlowProvider } from 'react-flow-renderer'
 import { buildEquivalenceBoxes, computeCoverRelations, computeRemainder } from '../utils/grouping'
 import NodeContextMenu from '../components/graph/NodeContextMenu'
 // @ts-ignore: type stub provided in global.d.ts; package installed at runtime
@@ -15,7 +15,7 @@ import CustomNode from '../components/graph/CustomNode'
 const groupNodeTypes: NodeTypes = { groupBox: GroupBoxNode, custom: CustomNode }
 
 // Placeholder Group view. Will be replaced with React Flow Sub Flows implementation in subsequent tasks.
-export default function GroupView() {
+function GroupViewInner() {
   const { currentProject } = useProjectStore()
   const activeTabId = useTabStore(s => s.activeTabId)
   const tabs = useTabStore(s => s.tabs)
@@ -889,4 +889,10 @@ export default function GroupView() {
   )
 }
 
-
+export default function GroupView() {
+  return (
+    <ReactFlowProvider>
+      <GroupViewInner />
+    </ReactFlowProvider>
+  )
+}

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -464,10 +464,11 @@ export default function GroupView() {
 
   const exportMapAsPng = useCallback(async () => {
     const toHide: HTMLElement[] = []
-    const styled: Array<{ el: HTMLElement; prev: { color?: string; backgroundColor?: string; fill?: string; stroke?: string; strokeWidth?: string } }> = []
+    const styled: Array<{ el: HTMLElement; prev: { color?: string; backgroundColor?: string; fill?: string; stroke?: string; strokeWidth?: string; attrStroke?: string | null; attrStrokeWidth?: string | null; attrFill?: string | null } }> = []
     const imageEvents: Array<{ src: string; ok: boolean; error?: any }> = []
     const originalImage = window.Image
     const scrubbedAttrs: Array<{ el: Element; name: string; prev: string }> = []
+    let prevViewport: { x: number; y: number; zoom: number } | null = null
     try {
       // Patch Image to log every load/error that html-to-image triggers
       // so we can deterministically see failing resources.
@@ -525,7 +526,7 @@ export default function GroupView() {
       }
 
       // Fit all nodes into view for export, then restore the viewport afterward
-      const prevViewport = getViewport ? getViewport() : null
+      prevViewport = getViewport ? getViewport() : null
       try {
         if (flowNodes.length > 0 && fitView) {
           await Promise.resolve(fitView({ includeHiddenNodes: true, padding: 0.2 }))
@@ -602,11 +603,12 @@ export default function GroupView() {
       const root = getComputedStyle(document.documentElement)
       const bgVar = root.getPropertyValue('--background').trim()
       const bgColor = bgVar ? `hsl(${bgVar})` : getComputedStyle(document.body).backgroundColor || '#fff'
+      const exportScale = 2 // upscale for crisper output
 
       // First generate SVG so we can inspect it deterministically
       const svgDataUrl = await htmlToImage.toSvg(flowRoot, {
         backgroundColor: bgColor,
-        pixelRatio: window.devicePixelRatio || 1,
+        pixelRatio: exportScale,
         cacheBust: true,
         // useCORS is supported at runtime; cast to satisfy types
         useCORS: true,
@@ -696,8 +698,8 @@ export default function GroupView() {
 
       // Draw to canvas manually to avoid hidden internals masking errors
       const canvas = document.createElement('canvas')
-      canvas.width = imgResult.w
-      canvas.height = imgResult.h
+      canvas.width = imgResult.w * exportScale
+      canvas.height = imgResult.h * exportScale
       const ctx = canvas.getContext('2d')
       if (!ctx) {
         toast.error('Failed to export map: no canvas context')
@@ -706,6 +708,7 @@ export default function GroupView() {
       // Paint background first for safety
       ctx.fillStyle = bgColor
       ctx.fillRect(0, 0, canvas.width, canvas.height)
+      ctx.scale(exportScale, exportScale)
       ctx.drawImage(await (() => new Promise<HTMLImageElement>((resolve, reject) => {
         const img = new Image()
         img.crossOrigin = 'anonymous'

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -118,7 +118,7 @@ export default function GroupView() {
     const groupNodes = enabled.map(g => ({
       groupId: g.id,
       nodeIds: nodesArr
-        .filter(n => matches(n, g.filters))
+        .filter(n => !n.isDirectory && matches(n, g.filters))
         .map(n => String(n?.metadata?.id || ''))
         .filter(Boolean),
     }))

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -13,6 +13,8 @@ import GroupBoxNode from '../components/graph/GroupBoxNode'
 import CustomNode from '../components/graph/CustomNode'
 import { getLayoutedElements } from '../utils/graphLayout'
 
+const groupNodeTypes: NodeTypes = { groupBox: GroupBoxNode, custom: CustomNode }
+
 // Placeholder Group view. Will be replaced with React Flow Sub Flows implementation in subsequent tasks.
 export default function GroupView() {
   const { currentProject } = useProjectStore()
@@ -539,7 +541,7 @@ export default function GroupView() {
       <ReactFlow
         nodes={nodesState}
         edges={edgesState}
-        nodeTypes={{ groupBox: GroupBoxNode, custom: CustomNode } as NodeTypes}
+        nodeTypes={groupNodeTypes}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onNodeDragStop={onNodeDragStop}

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -268,14 +268,23 @@ export default function GroupView() {
       })
     } else {
       // Nesting mode: recursively place children under each parent; duplicate children under multiple parents
-      const placeBox = (boxId: string, parentSafeId?: string, depth: number = 0, idx: number = 0) => {
+      const placeBox = (
+        boxId: string,
+        parentSafeId?: string,
+        depth: number = 0,
+        idx: number = 0,
+        forcedX?: number,
+        forcedY?: number,
+        forcedWidth?: number,
+        forcedHeight?: number
+      ) => {
         const b = equivalence.boxes.find(x => x.boxId === boxId)
         if (!b) return
         const safe = safeIdByBoxId.get(boxId)!
         const baseId = parentSafeId ? `${safe}__under__${parentSafeId}` : safe
         const saved = layout.boxes[baseId] || layout.boxes[safe] || layout.boxes[boxId]
-        const x = saved?.x ?? ((idx % perRow) * gridW + depth * 12)
-        const y = saved?.y ?? (Math.floor(idx / perRow) * gridH)
+        const x = parentSafeId ? (forcedX ?? 24) : (saved?.x ?? (idx % perRow) * gridW)
+        const y = parentSafeId ? (forcedY ?? 32) : (saved?.y ?? Math.floor(idx / perRow) * gridH)
         const isEq = b.groupIds.length > 1
 
         // If nested, parent sees only remainder; the child shows its own chips
@@ -288,15 +297,33 @@ export default function GroupView() {
         const displayedSet = isRoot ? remainder : b.nodeIds
         const totalCount = displayedSet.length
 
-        // Estimate height and width
-        const boxWidth = options.showNodeCards ? (parentSafeId ? 480 : 520) : (parentSafeId ? 240 : 260)
-        const columns = options.showNodeCards ? (boxWidth >= 520 ? 3 : 2) : 0
-        const estimateHeight = () => {
-          if (!options.showNodeCards) return 160
-          const count = (parentSafeId ? b.nodeIds : remainder).length
-          const rows = Math.ceil(Math.min(count, maxCards) / columns)
-          return 28 + rows * (80 + 12) + 24
-        }
+        // Sizes and padding for nested rendering
+        const boxWidth = forcedWidth ?? (options.showNodeCards ? (parentSafeId ? 480 : 520) : (parentSafeId ? 240 : 260))
+        const columns = options.showNodeCards ? (boxWidth >= 520 ? 3 : 2) : 1
+        const cardW = 180
+        const cardH = options.showNodeCards ? 80 : 48
+        const padX = 16
+        const padY = 16
+        const remainderRows = Math.ceil(Math.min(displayedSet.length, maxCards) / columns)
+        const remainderHeight = displayedSet.length === 0 ? 0 : remainderRows * (cardH + 12) + (displayedSet.length > 0 ? padY : 0)
+
+        // Precompute child sizes to size parent tightly
+        let childrenHeight = 0
+        const childSizes: Array<{ id: string; w: number; h: number }> = []
+        const childWidthBase = Math.max(200, boxWidth - 48)
+        directChildren.forEach(cid => {
+          const childBox = equivalence.boxes.find(x => x.boxId === cid)
+          const childCount = childBox ? Math.min(childBox.nodeIds.length, maxCards) : 0
+          const childCols = options.showNodeCards ? (childWidthBase >= 480 ? 3 : 2) : 1
+          const childRows = childCols > 0 ? Math.ceil(childCount / childCols) : 0
+          const childH = 24 + (childCount > 0 ? childRows * (cardH + 12) + padY : 0)
+          const childW = Math.min(boxWidth - 32, options.showNodeCards ? Math.max(240, childWidthBase) : Math.max(200, childWidthBase))
+          childSizes.push({ id: cid, w: childW, h: childH || (options.showNodeCards ? 120 : 80) })
+          childrenHeight += (childH || (options.showNodeCards ? 120 : 80)) + 12
+        })
+        if (childrenHeight > 0) childrenHeight += padY
+
+        const boxHeight = forcedHeight ?? (24 /*header*/ + remainderHeight + childrenHeight + padY)
 
         nodes.push({
           id: baseId,
@@ -312,7 +339,7 @@ export default function GroupView() {
             showCapIndicator: showCap,
           },
           position: { x, y },
-          style: { width: boxWidth, height: estimateHeight() },
+          style: { width: boxWidth, height: boxHeight },
           type: 'groupBox',
           draggable: !parentSafeId,
           parentNode: parentSafeId,
@@ -322,16 +349,16 @@ export default function GroupView() {
         // In nested mode with node cards, render only remainder nodes inside the parent box;
         // child boxes will render their own nodes.
         if (options.showNodeCards) {
-          const childIds = (parentSafeId ? b.nodeIds : remainder).slice(0, maxCards)
+          const childIds = (isRoot ? remainder : b.nodeIds).slice(0, maxCards)
           const columns = (boxWidth >= 520 ? 3 : 2)
           const cardW = 180
           const cardH = 80
-          const padX = 12, padY = 28
+          const padX = 12, padY = 20
           childIds.forEach((cid, cidx) => {
             const col = cidx % columns
             const row = Math.floor(cidx / columns)
             const cx = padX + col * (cardW + 12)
-            const cy = padY + row * (cardH + 12)
+            const cy = padY + row * (cardH + 12) + 24 // leave space for header
             const meta = idToMeta.get(cid)
             const path = idToPath.get(cid)
             const storeNode = path ? verbweaverNodes.get(path) : undefined
@@ -369,7 +396,17 @@ export default function GroupView() {
         }
 
         // Recurse children: duplicate under this baseId
-        directChildren.forEach((cid, cidx) => placeBox(cid, baseId, depth + 1, cidx))
+        if (directChildren.length > 0) {
+          let childY = 24 + remainderHeight + padY
+          directChildren.forEach(cid => {
+            const size = childSizes.find(s => s.id === cid)
+            const cWidth = size?.w ?? Math.min(boxWidth - 32, options.showNodeCards ? 360 : 240)
+            const cHeight = size?.h ?? (options.showNodeCards ? 140 : 100)
+            const cx = Math.max(16, (boxWidth - cWidth) / 2)
+            placeBox(cid, baseId, depth + 1, 0, cx, childY, cWidth, cHeight)
+            childY += cHeight + 12
+          })
+        }
       }
 
       topLevel.forEach((b, idx) => placeBox(b.boxId, undefined, 0, idx))

--- a/frontend/src/views/GroupView.tsx
+++ b/frontend/src/views/GroupView.tsx
@@ -179,6 +179,7 @@ export default function GroupView() {
     }
 
     const maxCards = Math.max(5, Math.min(200, Number(options.maxCardsPerGroup || 40)))
+    const showCap = options.showCapIndicator !== false
     if (!options.nestGroups) {
       equivalence.boxes.forEach((b, idx) => {
         const saved = layout.boxes[b.boxId]
@@ -186,11 +187,18 @@ export default function GroupView() {
         const y = saved?.y ?? Math.floor(idx / perRow) * gridH
         const isEq = b.groupIds.length > 1
         const totalCount = b.nodeIds.length
+        const boxWidth = options.showNodeCards ? 520 : 260
+        const columns = options.showNodeCards ? (boxWidth >= 520 ? 3 : 2) : 0
+        const estimateHeight = () => {
+          if (!options.showNodeCards) return 160
+          const rows = Math.ceil(Math.min(totalCount, maxCards) / columns)
+          return 28 + rows * (80 + 12) + 24
+        }
         nodes.push({
           id: b.boxId,
-          data: { label: boxIdToName.get(b.boxId) || 'Group', isEquivalent: isEq, chips: chipsFor(b.nodeIds), linkPairs: linkPairsFor(b.nodeIds), showNodeCards: !!options.showNodeCards, visibleCardCount: Math.min(totalCount, maxCards), totalCardCount: totalCount },
+          data: { label: boxIdToName.get(b.boxId) || 'Group', isEquivalent: isEq, chips: chipsFor(b.nodeIds), linkPairs: linkPairsFor(b.nodeIds), showNodeCards: !!options.showNodeCards, visibleCardCount: Math.min(totalCount, maxCards), totalCardCount: totalCount, showCapIndicator: showCap },
           position: { x, y },
-          style: { width: 260, height: 160 },
+          style: { width: boxWidth, height: estimateHeight() },
           type: 'groupBox',
           draggable: true,
         })
@@ -198,7 +206,7 @@ export default function GroupView() {
         // Show full node cards inside group (flat mode: all nodes of the set)
         if (options.showNodeCards) {
           const childIds = b.nodeIds.slice(0, maxCards)
-          const columns = 2
+          const columns = (boxWidth >= 520 ? 3 : 2)
           const cardW = 180
           const cardH = 80
           const padX = 12, padY = 28
@@ -266,12 +274,14 @@ export default function GroupView() {
         const displayedSet = isRoot ? remainder : b.nodeIds
         const totalCount = displayedSet.length
 
-        // Estimate height for root boxes in nested mode and larger boxes in card mode
+        // Estimate height and width
+        const boxWidth = options.showNodeCards ? (parent ? 480 : 520) : (parent ? 240 : 260)
+        const columns = options.showNodeCards ? (boxWidth >= 520 ? 3 : 2) : 0
         const estimateHeight = () => {
           if (!options.showNodeCards) return 160
           const count = (parent ? b.nodeIds : remainder).length
-          const rows = Math.ceil(Math.min(count, maxCards) / 2)
-          return 28 + rows * (80 + 12) + 24 // header + rows + padding
+          const rows = Math.ceil(Math.min(count, maxCards) / columns)
+          return 28 + rows * (80 + 12) + 24
         }
 
         nodes.push({
@@ -285,9 +295,10 @@ export default function GroupView() {
             showNodeCards: !!options.showNodeCards,
             visibleCardCount: Math.min(totalCount, maxCards),
             totalCardCount: totalCount,
+            showCapIndicator: showCap,
           },
           position: { x, y },
-          style: { width: options.showNodeCards ? (parent ? 480 : 520) : (parent ? 240 : 260), height: estimateHeight() },
+          style: { width: boxWidth, height: estimateHeight() },
           type: 'groupBox',
           draggable: !parent,
           parentNode: parent,
@@ -298,7 +309,7 @@ export default function GroupView() {
         // child boxes will render their own nodes.
         if (options.showNodeCards) {
           const childIds = (parent ? b.nodeIds : remainder).slice(0, maxCards)
-          const columns = 2
+          const columns = (boxWidth >= 520 ? 3 : 2)
           const cardW = 180
           const cardH = 80
           const padX = 12, padY = 28

--- a/package-lock.json
+++ b/package-lock.json
@@ -4993,9 +4993,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001762",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
+      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "devDependencies": {
         "@types/node": "^20.10.4",
         "cross-env": "^7.0.3",
-        "electron": "^38.4.0",
+        "electron": "^38.5.0",
         "electron-builder": "^26.0.12",
         "electron-vite": "^3.1.0",
         "typescript": "^5.3.3"
@@ -6155,9 +6155,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "38.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.4.0.tgz",
-      "integrity": "sha512-9CsXKbGf2qpofVe2pQYSgom2E//zLDJO2rGLLbxgy9tkdTOs7000Gte+d/PUtzLjI/DS95jDK0ojYAeqjLvpYg==",
+      "version": "38.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.5.0.tgz",
+      "integrity": "sha512-dbC7V+eZweerYMJfxQldzHOg37a1VdNMCKxrJxlkp3cA30gOXtXSg4ZYs07L5+QwI19WOy1uyvtEUgbw1RRsCQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5453,9 +5453,9 @@
       }
     },
     "node_modules/config-file-ts/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7670,9 +7670,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -8313,9 +8313,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8934,9 +8934,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -11917,9 +11917,9 @@
       }
     },
     "node_modules/sucrase/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "devDependencies": {
         "@types/node": "^20.10.4",
         "cross-env": "^7.0.3",
-        "electron": "^38.5.0",
+        "electron": "^38.7.2",
         "electron-builder": "^26.0.12",
         "electron-vite": "^3.1.0",
         "typescript": "^5.3.3"
@@ -6155,9 +6155,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "38.5.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.5.0.tgz",
-      "integrity": "sha512-dbC7V+eZweerYMJfxQldzHOg37a1VdNMCKxrJxlkp3cA30gOXtXSg4ZYs07L5+QwI19WOy1uyvtEUgbw1RRsCQ==",
+      "version": "38.7.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.7.2.tgz",
+      "integrity": "sha512-BcjR0IHqp3uv4ytVQwW2/9zAWo17Rjwrydn6RS+g+vqhpcPTzmBHDCHKaEcqheSl/7zzKPgFZdvT21BoSfrxRQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",


### PR DESCRIPTION
Added a Group mode to the Graph View that allows the user to create multiple sets of filters and render each on a canvas. The user can do things like create a Group by filtering for a specific tag (such as device type in a network diagram). They will see that group and any other that they wish to see.

<img width="3129" height="1713" alt="image" src="https://github.com/user-attachments/assets/de299548-5e4a-4852-a426-2a755c533ef0" />


Additionally, groups can be viewed in nesting mode so that superset Groups are rendered as containing subsets Groups.

<img width="3132" height="1728" alt="image" src="https://github.com/user-attachments/assets/8ff3109a-957c-44dc-b492-9d716e8440b0" />

 There is also a Cards mode.
 
<img width="3123" height="1731" alt="image" src="https://github.com/user-attachments/assets/e4f824d8-2ac6-4525-9357-5bc360b669b1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a fourth Graph sub-view, enabling set-based visualization and management.
> 
> - New `Group` view (`frontend/src/views/GroupView.tsx`) renders filter-defined groups using React Flow; supports flat Hasse-diagram edges or nested boxes, with optional in-group node cards and soft-link edges
> - Group management UI: `GroupManagerPanel.tsx` (create/enable/rename/delete up to 50 groups; per-group filters) and `GroupOptionsTray.tsx` (nesting, show node cards, max cards, cap indicator, JSON export/import)
> - State/persistence: `useGroupViewStore` (`frontend/src/store/groupViewState.ts`) with per-tab localStorage save/load and config export/import
> - Group layout/logic: `frontend/src/utils/grouping.ts` (equivalence boxes, subset cover reduction, remainders) with a lightweight spec (`grouping.spec.ts`)
> - Graph wiring: sub-view switcher updated in `Graph.tsx`; context menu variant in `NodeContextMenu.tsx` adds canvas "Save as PNG"; new `GroupBoxNode` component for group boxes
> - Docs: `docs/graph-view.md` updated to include Group view and usage; Desktop Electron devDependency bumped to `^38.7.2` (lockfile updated)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dc73886037986ff9b699ca8c2dfd63f004d6579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->